### PR TITLE
Use Python 3.6 for Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.6
         exclude_types: ['markdown', 'ini', 'toml', 'rst']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This prevents Black from using Python 3.7+ only syntax when you still support for Python 3.6.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
