### PR TITLE
Include GitHub action on push and pr

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -1,0 +1,22 @@
+name: test-on-push-and-pr
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      env:
+        GITHUB_WORKSPACE: /
+    - name: Set up python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Run 'pr' target
+      run: make pr

--- a/test/integration/codebuild-local/codebuild_build.sh
+++ b/test/integration/codebuild-local/codebuild_build.sh
@@ -95,7 +95,7 @@ then
     exit 1
 fi
 
-docker_command="docker run -it "
+docker_command="docker run "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "

--- a/test/integration/codebuild-local/test_one.sh
+++ b/test/integration/codebuild-local/test_one.sh
@@ -31,7 +31,7 @@ main() {
     RUNTIME_VERSION="$4"
     EXTRA_ENV="${5-}"
 
-    CODEBUILD_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}"codebuild."$OS_DISTRIBUTION"-"$DISTRO_VERSION"-"$RUNTIME_VERSION".XXXXXXXXXX)
+    CODEBUILD_TEMP_DIR=$(mktemp -d codebuild."$OS_DISTRIBUTION"-"$DISTRO_VERSION"-"$RUNTIME_VERSION".XXXXXXXXXX)
     trap 'rm -rf $CODEBUILD_TEMP_DIR' EXIT
 
     # Create an env file for codebuild_build.

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -288,11 +288,13 @@ class TestHandleEventRequest(unittest.TestCase):
             xray_fault["exceptions"][0]["stack"][0]["label"], "raise_exception_handler"
         )
         self.assertIsInstance(xray_fault["exceptions"][0]["stack"][0]["line"], int)
-        self.assertEqual(
-            xray_fault["exceptions"][0]["stack"][0]["path"], os.path.realpath(__file__)
+        self.assertTrue(
+            xray_fault["exceptions"][0]["stack"][0]["path"].endswith(
+                os.path.relpath(__file__)
+            )
         )
         self.assertEqual(len(xray_fault["paths"]), 1)
-        self.assertEqual(xray_fault["paths"][0], os.path.realpath(__file__))
+        self.assertTrue(xray_fault["paths"][0].endswith(os.path.relpath(__file__)))
 
     def test_handle_event_request_no_module(self):
         def unable_to_import_module(json_input, lambda_context):


### PR DESCRIPTION
*Description of changes:*
* Added GitHub workflow to run the required checks on push and pr
* Removed unnecessary `-it` option from `codebuild_build.sh` because it was causing `tty` error when running the GitHub action.
* Refactored some assertions in a test in order to be compatible with GitHub Actions environment
* Removed unnecessary `/tmp` path from `mktemp` command that was causing rights issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
