### PR TITLE
Added 'docker login' to fix pull rate limit issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ Then,
 * to run integration tests: `make test-integ`
 * to run smoke tests: `make test-smoke`
 
+### Troubleshooting
+While running integration tests, you might encounter the Docker Hub rate limit error with the following body:
+```
+You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limits
+```
+To fix the above issue, consider authenticating to a Docker Hub account by setting the Docker Hub credentials as below CodeBuild environment variables.
+```shell script
+DOCKERHUB_USERNAME=<dockerhub username>
+DOCKERHUB_PASSWORD=<dockerhub password>
+```
+Recommended way is to set the Docker Hub credentials in CodeBuild job by retrieving them from AWS Secrets Manager.
 ## Security
 
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.

--- a/test/integration/codebuild/buildspec.os.alpine.1.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.1.yml
@@ -37,6 +37,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.alpine.2.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.2.yml
@@ -39,6 +39,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.alpine.3.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.3.yml
@@ -39,6 +39,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.amazonlinux.yml
+++ b/test/integration/codebuild/buildspec.os.amazonlinux.yml
@@ -37,6 +37,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.centos.1.yml
+++ b/test/integration/codebuild/buildspec.os.centos.1.yml
@@ -36,6 +36,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.centos.2.yml
+++ b/test/integration/codebuild/buildspec.os.centos.2.yml
@@ -36,6 +36,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.debian.yml
+++ b/test/integration/codebuild/buildspec.os.debian.yml
@@ -36,6 +36,17 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
+      - >
+        echo "RUN apt-get update && apt-get install -y curl" >> \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.ubuntu.1.yml
+++ b/test/integration/codebuild/buildspec.os.ubuntu.1.yml
@@ -35,6 +35,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \

--- a/test/integration/codebuild/buildspec.os.ubuntu.2.yml
+++ b/test/integration/codebuild/buildspec.os.ubuntu.2.yml
@@ -34,6 +34,14 @@ phases:
       - >
         echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
           "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
       - echo "Building image ${IMAGE_TAG}"
       - >
         docker build . \


### PR DESCRIPTION
*Description of changes:*

- Added "docker login" for authenticating to dockerHub account while running integration tests. This will fix the docker hub rate limit error while pulling the images.

- Docker Hub credentials need to be set as CodeBuild environment variables as described in the README's Troubleshooting section.

- Added curl installation to fix below issue in Debian image
```
sh: 1: curl: not found
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
