### PR TITLE
Revise fetching latest patch version of python

### DIFF
--- a/test/integration/docker/Dockerfile.echo.amazonlinux
+++ b/test/integration/docker/Dockerfile.echo.amazonlinux
@@ -23,8 +23,15 @@ RUN yum install -y \
   libffi-devel \
   sqlite-devel
 
-RUN RUNTIME_LATEST_VERSION=${RUNTIME_VERSION}.$(curl -s https://www.python.org/ftp/python/ | grep -oE "href=\"$(echo ${RUNTIME_VERSION} | sed "s/\\./\\\./g")\.[0-9]+" | cut -d. -f3 | sort -n | tail -n1) \
-  && wget -c https://www.python.org/ftp/python/${RUNTIME_LATEST_VERSION}/Python-${RUNTIME_LATEST_VERSION}.tgz -O - | tar -xz \
+RUN RUNTIME_LATEST_VERSION=${RUNTIME_VERSION}.$(curl -s https://www.python.org/ftp/python/ | \
+                                                grep -oE "href=\"$(echo ${RUNTIME_VERSION} | sed "s/\\./\\\./g")\.[0-9]+" | \
+                                                cut -d. -f3 | \
+                                                sort -rn | \
+                                                while read -r patch; do \
+                                                  $(wget -c https://www.python.org/ftp/python/${RUNTIME_VERSION}.$patch/Python-${RUNTIME_VERSION}.$patch.tgz -O Python-${RUNTIME_VERSION}.$patch.tgz); \
+                                                  [ $? -eq 0 ] && echo $patch && break; \
+                                                done) \
+  && tar -xzf Python-${RUNTIME_LATEST_VERSION}.tgz \
   && cd Python-${RUNTIME_LATEST_VERSION} \
   && ./configure --prefix=/usr/local --enable-shared \
   && make \

--- a/test/integration/docker/Dockerfile.echo.centos
+++ b/test/integration/docker/Dockerfile.echo.centos
@@ -23,8 +23,15 @@ RUN yum install -y \
   libffi-devel \
   sqlite-devel
 
-RUN RUNTIME_LATEST_VERSION=${RUNTIME_VERSION}.$(curl -s https://www.python.org/ftp/python/ | grep -oE "href=\"$(echo ${RUNTIME_VERSION} | sed "s/\\./\\\./g")\.[0-9]+" | cut -d. -f3 | sort -n | tail -n1) \
-  && wget -c https://www.python.org/ftp/python/${RUNTIME_LATEST_VERSION}/Python-${RUNTIME_LATEST_VERSION}.tgz -O - | tar -xz \
+RUN RUNTIME_LATEST_VERSION=${RUNTIME_VERSION}.$(curl -s https://www.python.org/ftp/python/ | \
+                                                grep -oE "href=\"$(echo ${RUNTIME_VERSION} | sed "s/\\./\\\./g")\.[0-9]+" | \
+                                                cut -d. -f3 | \
+                                                sort -rn | \
+                                                while read -r patch; do \
+                                                  $(wget -c https://www.python.org/ftp/python/${RUNTIME_VERSION}.$patch/Python-${RUNTIME_VERSION}.$patch.tgz -O Python-${RUNTIME_VERSION}.$patch.tgz); \
+                                                  [ $? -eq 0 ] && echo $patch && break; \
+                                                done) \
+  && tar -xzf Python-${RUNTIME_LATEST_VERSION}.tgz \
   && cd Python-${RUNTIME_LATEST_VERSION} \
   && ./configure --prefix=/usr/local --enable-shared \
   && make \


### PR DESCRIPTION
*Description of changes:*
- In the buildspec files for OS compatibility tests only the major.minor version of python is specified. Then, in the Dockerfile the latest patch version is fetched.
The problem with this is that it can happen that there will be a patch version not released yet, but there is a release candidate for that (at the moment it is for [Python 3.8.7](https://www.python.org/ftp/python/3.8.7/)). This will cause an error.
Modified so that every patch version is tried from the latest one to the earliest one until a valid one is found.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
