### PR TITLE
errorMessage field is missing from exception response

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -90,13 +90,9 @@ def make_fault_handler(fault):
 
 
 def make_error(error_message, error_type, stack_trace):
-    result = {}
-    if error_message:
-        result["errorMessage"] = error_message
-    if error_type:
-        result["errorType"] = error_type
-    if stack_trace:
-        result["stackTrace"] = stack_trace
+    result = {'errorMessage': error_message if error_message else "",
+                'errorType': error_type if error_type else "",
+                'stackTrace': stack_trace if stack_trace else []}
     return result
 
 

--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -90,9 +90,11 @@ def make_fault_handler(fault):
 
 
 def make_error(error_message, error_type, stack_trace):
-    result = {'errorMessage': error_message if error_message else "",
-                'errorType': error_type if error_type else "",
-                'stackTrace': stack_trace if stack_trace else []}
+    result = {
+        "errorMessage": error_message if error_message else "",
+        "errorType": error_type if error_type else "",
+        "stackTrace": stack_trace if stack_trace else [],
+    }
     return result
 
 

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -435,7 +435,7 @@ class TestHandleEventRequest(unittest.TestCase):
             0,
             bootstrap.StandardLogSink(),
         )
-        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\n"
+        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -461,7 +461,7 @@ class TestHandleEventRequest(unittest.TestCase):
             0,
             bootstrap.StandardLogSink(),
         )
-        error_logs = "[ERROR] FaultExceptionType\n"
+        error_logs = "[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -487,7 +487,7 @@ class TestHandleEventRequest(unittest.TestCase):
             0,
             bootstrap.StandardLogSink(),
         )
-        error_logs = "[ERROR] Fault exception msg\n"
+        error_logs = "[ERROR] Fault exception msg\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -835,7 +835,7 @@ class TestLogError(unittest.TestCase):
         err_to_log = bootstrap.make_error("Error message", "ErrorType", None)
         bootstrap.log_error(err_to_log, bootstrap.StandardLogSink())
 
-        expected_logged_error = "[ERROR] ErrorType: Error message\n"
+        expected_logged_error = "[ERROR] ErrorType: Error message\rTraceback (most recent call last):\n"
         self.assertEqual(mock_stdout.getvalue(), expected_logged_error)
 
     def test_log_error_framed_log_sink(self):
@@ -844,13 +844,16 @@ class TestLogError(unittest.TestCase):
                 err_to_log = bootstrap.make_error("Error message", "ErrorType", None)
                 bootstrap.log_error(err_to_log, log_sink)
 
-            expected_logged_error = "[ERROR] ErrorType: Error message"
+            expected_logged_error = "[ERROR] ErrorType: Error message\nTraceback (most recent call last):"
 
             with open(temp_file.name, "rb") as f:
                 content = f.read()
 
                 frame_type = int.from_bytes(content[:4], "big")
                 self.assertEqual(frame_type, 0xA55A0001)
+
+                actual_message = content[8:].decode()
+                self.assertEqual(actual_message, expected_logged_error)
 
                 length = int.from_bytes(content[4:8], "big")
                 self.assertEqual(length, len(expected_logged_error.encode("utf8")))

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -852,9 +852,6 @@ class TestLogError(unittest.TestCase):
                 frame_type = int.from_bytes(content[:4], "big")
                 self.assertEqual(frame_type, 0xA55A0001)
 
-                actual_message = content[8:].decode()
-                self.assertEqual(actual_message, expected_logged_error)
-
                 length = int.from_bytes(content[4:8], "big")
                 self.assertEqual(length, len(expected_logged_error.encode("utf8")))
 


### PR DESCRIPTION
*Description of changes:*

Fix for missing "errorMessage" field from exception response, when "errorMessage" field is "" or None, handled the same case for "errorType" and "stackTrace" fields in exception response.

Updated unit test case accordingly.

Tested by running test_bootstrap.py and integration test suite.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
