### PR TITLE
Correctly format stdout (StandardSink) multi-line errors

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -19,7 +19,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import imp
 
-ERROR_LOG_LINE_TERMINATE = "\r"
+ERROR_LOG_LINE_TERMINATE = "\r\n"
 ERROR_LOG_IDENT = "\u00a0"  # NO-BREAK SPACE U+00A0
 
 

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -404,11 +404,11 @@ class TestHandleEventRequest(unittest.TestCase):
         )
 
         # NOTE: Indentation characters are NO-BREAK SPACE (U+00A0) not SPACE (U+0020)
-        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\r"
-        error_logs += "Traceback (most recent call last):\r"
-        error_logs += '  File "spam.py", line 3, in <module>\r'
-        error_logs += "    spam.eggs()\r"
-        error_logs += '  File "eggs.py", line 42, in eggs\r'
+        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\r\n"
+        error_logs += "Traceback (most recent call last):\r\n"
+        error_logs += '  File "spam.py", line 3, in <module>\r\n'
+        error_logs += "    spam.eggs()\r\n"
+        error_logs += '  File "eggs.py", line 42, in eggs\r\n'
         error_logs += '    return "bacon"\n'
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
@@ -523,11 +523,11 @@ class TestHandleEventRequest(unittest.TestCase):
             bootstrap.StandardLogSink(),
         )
 
-        error_logs = "[ERROR]\r"
-        error_logs += "Traceback (most recent call last):\r"
-        error_logs += '  File "spam.py", line 3, in <module>\r'
-        error_logs += "    spam.eggs()\r"
-        error_logs += '  File "eggs.py", line 42, in eggs\r'
+        error_logs = "[ERROR]\r\n"
+        error_logs += "Traceback (most recent call last):\r\n"
+        error_logs += '  File "spam.py", line 3, in <module>\r\n'
+        error_logs += "    spam.eggs()\r\n"
+        error_logs += '  File "eggs.py", line 42, in eggs\r\n'
         error_logs += '    return "bacon"\n'
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
@@ -566,9 +566,9 @@ class TestHandleEventRequest(unittest.TestCase):
 
         sys.stderr.write(mock_stdout.getvalue())
 
-        error_logs = "[ERROR] Runtime.UserCodeSyntaxError: Syntax error in module 'a': unexpected EOF while parsing (<string>, line 1)\r"
-        error_logs += "Traceback (most recent call last):\r"
-        error_logs += '  File "<string>" Line 1\r'
+        error_logs = "[ERROR] Runtime.UserCodeSyntaxError: Syntax error in module 'a': unexpected EOF while parsing (<string>, line 1)\r\n"
+        error_logs += "Traceback (most recent call last):\r\n"
+        error_logs += '  File "<string>" Line 1\r\n'
         error_logs += "    -\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
@@ -764,7 +764,7 @@ class TestContentType(unittest.TestCase):
         )
 
     def test_binary_request_binary_response(self):
-        event_body = b"\x89PNG\r\n\x1a\n\x00\x00\x00"
+        event_body = b"\x89PNG\r\n\n\x1a\n\x00\x00\x00"
         bootstrap.handle_event_request(
             lambda_runtime_client=self.lambda_runtime,
             request_handler=lambda event, ctx: event,
@@ -783,7 +783,7 @@ class TestContentType(unittest.TestCase):
         )
 
     def test_json_request_binary_response(self):
-        binary_data = b"\x89PNG\r\n\x1a\n\x00\x00\x00"
+        binary_data = b"\x89PNG\r\n\n\x1a\n\x00\x00\x00"
         bootstrap.handle_event_request(
             lambda_runtime_client=self.lambda_runtime,
             request_handler=lambda event, ctx: binary_data,
@@ -806,7 +806,7 @@ class TestContentType(unittest.TestCase):
             lambda_runtime_client=self.lambda_runtime,
             request_handler=lambda event, ctx: event,
             invoke_id="invoke-id",
-            event_body=b"\x89PNG\r\n\x1a\n\x00\x00\x00",
+            event_body=b"\x89PNG\r\n\n\x1a\n\x00\x00\x00",
             content_type="application/json",
             client_context_json=None,
             cognito_identity_json=None,
@@ -865,7 +865,7 @@ class TestLogError(unittest.TestCase):
         )
         bootstrap.log_error(err_to_log, bootstrap.StandardLogSink())
 
-        expected_logged_error = "[ERROR] ErrorType: Error message\rTraceback (most recent call last):\r\xa0\xa0line1  \r\xa0\xa0line2  \r\xa0\xa0\n"
+        expected_logged_error = "[ERROR] ErrorType: Error message\r\nTraceback (most recent call last):\r\n\xa0\xa0line1  \r\n\xa0\xa0line2  \r\n\xa0\xa0\n"
         self.assertEqual(mock_stdout.getvalue(), expected_logged_error)
 
     def test_log_error_indentation_framed_log_sink(self):
@@ -897,7 +897,7 @@ class TestLogError(unittest.TestCase):
         )
         bootstrap.log_error(err_to_log, bootstrap.StandardLogSink())
 
-        expected_logged_error = "[ERROR] ErrorType: Error message\rTraceback (most recent call last):\rline1\r\rline2\n"
+        expected_logged_error = "[ERROR] ErrorType: Error message\r\nTraceback (most recent call last):\r\nline1\r\n\r\nline2\n"
         self.assertEqual(mock_stdout.getvalue(), expected_logged_error)
 
     def test_log_error_empty_stacktrace_line_framed_log_sink(self):


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-python-runtime-interface-client/issues/14

*Description of changes:*  The StandardSink logger outputs multi-line errors with lines separated by "\r".  On many systems, this results in just one line of output with all lines merged on top of each other, which is a mess for stack traces.  This change alters the separator to include newlines ("\r\n"), which should clean up multi-line errors and stacktrace output for most systems.


