### PR TITLE
Use importlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Test files generated
+tmp*.py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ coverage>=4.4.0
 flake8>=3.3.0
 tox>=2.2.1
 pytest-cov>=2.4.0
-pylint>=1.7.2,<2.0
+pylint>=1.7.2
 black>=20.8b0
 bandit>=1.6.2
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -690,7 +690,9 @@ class TestGetEventHandler(unittest.TestCase):
 
     def test_get_event_handler_syntax_error(self):
         importlib.invalidate_caches()
-        with tempfile.NamedTemporaryFile(suffix=".py", dir=".", delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", dir=".", delete=False
+        ) as tmp_file:
             tmp_file.write(
                 b"def syntax_error()\n\tprint('syntax error, no colon after function')"
             )
@@ -715,7 +717,9 @@ class TestGetEventHandler(unittest.TestCase):
 
     def test_get_event_handler_missing_error(self):
         importlib.invalidate_caches()
-        with tempfile.NamedTemporaryFile(suffix=".py", dir=".", delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", dir=".", delete=False
+        ) as tmp_file:
             tmp_file.write(b"def wrong_handler_name():\n\tprint('hello')")
             tmp_file.flush()
 


### PR DESCRIPTION
### Problem

Remove `imp` in favor of `importlib`

`imp` module is deprecated since Python 3.3

The previous implementation had some issues while trying to load python modules ( execute `__init__.py` files) when you specify a handler in a directory. 

By using `importlib` these issues go away and the implementation is way easier.

### Description of changes

- Remove usages of `imp.find_module` and `imp.load_module` and use `importlib.import_module`.
- Relax `pylint` version since the pinned version wasn't supported by Python 3.8.
- Fix and improve tests.

**Source**

https://docs.python.org/3/library/imp.html#imp.find_module

> Deprecated since version 3.3: Use importlib.util.find_spec() instead unless Python 3.3 compatibility is required, in which case use importlib.find_loader(). For example usage of the former case, see the Examples section of the importlib documentation.

https://docs.python.org/3/library/imp.html#imp.load_module

> Deprecated since version 3.3: If previously used in conjunction with imp.find_module() then consider using importlib.import_module(), otherwise use the loader returned by the replacement you chose for imp.find_module(). If you called imp.load_module() and related functions directly with file path arguments then use a combination of importlib.util.spec_from_file_location() and importlib.util.module_from_spec(). See the Examples section of the importlib documentation for details of the various approaches.

https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches

> If you are dynamically importing a module that was created since the interpreter began execution (e.g., created a Python source file), you may need to call invalidate_caches() in order for the new module to be noticed by the import system.