### PR TITLE
[Superseded] Release GIL when polling Runtime API for next invocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_curl_extra_linker_flags():
 def get_runtime_client_extension():
     if platform.system() != "Linux" and os.getenv("BUILD") != "true":
         print(
-            "The native runtime_client only builds in Linux. Skiping its compilation."
+            "The native runtime_client only builds on Linux. Skipping its compilation."
         )
         return []
 


### PR DESCRIPTION
### Notes
`runtime_client` is holding the GIL (Global Interpreter Lock) while it is polling for the `runtime/invocation/next` invocation, which is meant to be an async I/O operation.

According to the [Python extension docs on Initialization, Finalization, and Threads](https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock), any blocking I/O should release the lock explicitly to allow other code to continue. This is especially true for extensions where developers (us, in this case) should manage releasing/reacquiring the lock.

> Without the lock, even the simplest operations could cause problems in a multi-threaded program: for example, when two threads simultaneously increment the reference count of the same object, the reference count could end up being incremented only once instead of twice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
