### PR TITLE
Release GIL when polling Runtime API for next invocation

### DIFF
--- a/awslambdaric/runtime_client.cpp
+++ b/awslambdaric/runtime_client.cpp
@@ -25,18 +25,25 @@ static PyObject *method_initialize_client(PyObject *self, PyObject *args) {
 }
 
 static PyObject *method_next(PyObject *self) {
-    if (CLIENT == nullptr) {
-        PyErr_SetString(PyExc_RuntimeError, "Client not yet initalized");
-        return NULL;
-    }
+    aws::lambda_runtime::invocation_request response;
+
+    // Release GIL and save thread state
+    // ref: https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock
+    PyThreadState *_save;
+    _save = PyEval_SaveThread();
 
     auto outcome = CLIENT->get_next();
     if (!outcome.is_success()) {
+        // Reacquire GIL before exiting
+        PyEval_RestoreThread(_save);
         PyErr_SetString(PyExc_RuntimeError, "Failed to get next");
         return NULL;
     }
 
-    auto response = outcome.get_result();
+    response = outcome.get_result();
+    // Reacquire GIL before constructing return object
+    PyEval_RestoreThread(_save);
+
     auto payload = response.payload;
     auto request_id = response.request_id.c_str();
     auto trace_id = response.xray_trace_id.c_str();

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_curl_extra_linker_flags():
 def get_runtime_client_extension():
     if platform.system() != "Linux" and os.getenv("BUILD") != "true":
         print(
-            "The native runtime_client only builds in Linux. Skiping its compilation."
+            "The native runtime_client only builds on Linux. Skipping its compilation."
         )
         return []
 


### PR DESCRIPTION
### Notes
`runtime_client` is holding the GIL (Global Interpreter Lock) while it is polling for the `runtime/invocation/next` invocation, which is meant to be an async I/O operation.

According to the [Python extension docs on Initialization, Finalization, and Threads](https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock), any blocking I/O should release the lock explicitly to allow other code to continue. This is especially true for extensions where developers (us, in this case) should manage releasing/reacquiring the lock.

> Without the lock, even the simplest operations could cause problems in a multi-threaded program: for example, when two threads simultaneously increment the reference count of the same object, the reference count could end up being incremented only once instead of twice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
