### PR TITLE
(#37) Adds '--no-same-owner' option to all scripts tar commands

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -23,8 +23,8 @@ else
     rm -rf ./aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE
 
     # unpack dependencies
-    tar xzf ./curl-$CURL_VERSION.tar.gz && \
-    tar xzf ./aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz
+    tar xzf ./curl-$CURL_VERSION.tar.gz --no-same-owner && \
+    tar xzf ./aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz --no-same-owner
 
     (
         # Build Curl

--- a/scripts/update_deps.sh
+++ b/scripts/update_deps.sh
@@ -25,5 +25,5 @@ wget -c https://github.com/awslabs/aws-lambda-cpp/archive/v$AWS_LAMBDA_CPP_RELEA
 )
 
 ## Pack again and remove the folder
-tar -czvf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE && \
+tar -czvf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE --no-same-owner && \
   rm -rf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE


### PR DESCRIPTION
*Issue #37:* 

Fix for the error _Cannot change ownership to uid 1515433866, gid 1896053708_ raised while installing from a container as root.

Indeed:
* High UIDs and GIDs are not accepted from Docker containers
* As root (only), by default, the *tar* command extracts files using the ownership described in the archive (not of the FS)

*Description of changes:*

Adds tar option `--no-same-owner` so that the ownership is not forced in the destination and the python module can be installed as root from a container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
