### PR TITLE
Add Support for / in handler name

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -36,6 +36,7 @@ def _get_handler(handler):
                 "Cannot use built-in module {} as a handler module".format(modname),
             )
             return make_fault_handler(fault)
+        modname = modname.replace("/", ".")
         m = importlib.import_module(modname)
     except ImportError as e:
         fault = FaultException(

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def read_requirements(req="base.txt"):
 
 setup(
     name="awslambdaric",
-    version="1.1.1",
+    version="1.2.1",
     author="Amazon Web Services",
     description="AWS Lambda Runtime Interface Client for Python",
     long_description=read("README.md"),

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -780,6 +780,12 @@ class TestGetEventHandler(unittest.TestCase):
                 returned_exception,
             )
 
+    def test_get_event_handler_slash(self):
+        importlib.invalidate_caches()
+        handler_name = "tests/test_handler_with_slash/test_handler.my_handler"
+        response_handler = bootstrap._get_handler(handler_name)
+        response_handler()
+
     def test_get_event_handler_build_in_conflict(self):
         response_handler = bootstrap._get_handler("sys.hello")
         with self.assertRaises(FaultException) as cm:
@@ -792,6 +798,18 @@ class TestGetEventHandler(unittest.TestCase):
             ),
             returned_exception,
         )
+
+    def test_get_event_handler_doesnt_throw_build_in_module_name_slash(self):
+        response_handler = bootstrap._get_handler(
+            "tests/test_built_in_module_name/sys.my_handler"
+        )
+        response_handler()
+
+    def test_get_event_handler_doent_throw_build_in_module_name(self):
+        response_handler = bootstrap._get_handler(
+            "tests.test_built_in_module_name.sys.my_handler"
+        )
+        response_handler()
 
 
 class TestContentType(unittest.TestCase):

--- a/tests/test_built_in_module_name/sys.py
+++ b/tests/test_built_in_module_name/sys.py
@@ -1,0 +1,2 @@
+def my_handler():
+    return "Same name as Built in module, but different path"

--- a/tests/test_handler_with_slash/test_handler.py
+++ b/tests/test_handler_with_slash/test_handler.py
@@ -1,0 +1,2 @@
+def my_handler():
+    return "Good with slash"


### PR DESCRIPTION
https://github.com/aws/aws-lambda-python-runtime-interface-client/issues/43
- Support for / in handler name
- Added test for the same
- Updated to get the module name to check for builtin module even if customer gives handler name with (a.b.module_name)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
