### PR TITLE
Move the / to . replcement only for import_module call, error message was impacted

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -36,8 +36,7 @@ def _get_handler(handler):
                 "Cannot use built-in module {} as a handler module".format(modname),
             )
             return make_fault_handler(fault)
-        modname = modname.replace("/", ".")
-        m = importlib.import_module(modname)
+        m = importlib.import_module(modname.replace("/", "."))
     except ImportError as e:
         fault = FaultException(
             FaultException.IMPORT_MODULE_ERROR,


### PR DESCRIPTION
- It impacted the error message in case user handler name is a/module1.handler, and the module was not found it would raise error as a.module1 not found rather than a/module1 is not found. Corrected this behavior



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
