### PR TITLE
Using the raw fd directly rather than opening the fd pseudo file

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -322,12 +322,12 @@ class FramedTelemetryLogSink(object):
     big-endian.
     """
 
-    def __init__(self, filename):
-        self.filename = filename
+    def __init__(self, fd):
+        self.fd = int(fd)
         self.frame_type = 0xA55A0001 .to_bytes(4, "big")
 
     def __enter__(self):
-        self.file = open(self.filename, "wb", 0)
+        self.file = os.fdopen(self.fd, 'wb', 0)
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
@@ -355,7 +355,7 @@ def create_log_sink():
     if "_LAMBDA_TELEMETRY_LOG_FD" in os.environ:
         fd = os.environ["_LAMBDA_TELEMETRY_LOG_FD"]
         del os.environ["_LAMBDA_TELEMETRY_LOG_FD"]
-        return FramedTelemetryLogSink("/proc/self/fd/" + fd)
+        return FramedTelemetryLogSink(fd)
 
     else:
         return StandardLogSink()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -914,7 +914,7 @@ class TestLogError(unittest.TestCase):
 
     def test_log_error_framed_log_sink(self):
         with NamedTemporaryFile() as temp_file:
-            with bootstrap.FramedTelemetryLogSink(temp_file.name) as log_sink:
+            with bootstrap.FramedTelemetryLogSink(os.open(temp_file.name, os.O_CREAT | os.O_RDWR)) as log_sink:
                 err_to_log = bootstrap.make_error("Error message", "ErrorType", None)
                 bootstrap.log_error(err_to_log, log_sink)
 
@@ -949,7 +949,7 @@ class TestLogError(unittest.TestCase):
 
     def test_log_error_indentation_framed_log_sink(self):
         with NamedTemporaryFile() as temp_file:
-            with bootstrap.FramedTelemetryLogSink(temp_file.name) as log_sink:
+            with bootstrap.FramedTelemetryLogSink(os.open(temp_file.name, os.O_CREAT | os.O_RDWR)) as log_sink:
                 err_to_log = bootstrap.make_error(
                     "Error message", "ErrorType", ["  line1  ", "  line2  ", "  "]
                 )
@@ -984,7 +984,7 @@ class TestLogError(unittest.TestCase):
 
     def test_log_error_empty_stacktrace_line_framed_log_sink(self):
         with NamedTemporaryFile() as temp_file:
-            with bootstrap.FramedTelemetryLogSink(temp_file.name) as log_sink:
+            with bootstrap.FramedTelemetryLogSink(os.open(temp_file.name, os.O_CREAT | os.O_RDWR)) as log_sink:
                 err_to_log = bootstrap.make_error(
                     "Error message", "ErrorType", ["line1", "", "line2"]
                 )
@@ -1070,19 +1070,19 @@ class TestLogSink(unittest.TestCase):
         self.assertEqual(mock_stdout.getvalue(), "log")
 
     def test_create_framed_telemetry_log_sinks(self):
-        fd = "test_fd"
-        os.environ["_LAMBDA_TELEMETRY_LOG_FD"] = fd
+        fd = 3
+        os.environ["_LAMBDA_TELEMETRY_LOG_FD"] = "3"
 
         actual = bootstrap.create_log_sink()
 
         self.assertIsInstance(actual, bootstrap.FramedTelemetryLogSink)
-        self.assertEqual(actual.filename, "/proc/self/fd/" + fd)
+        self.assertEqual(actual.fd, fd)
         self.assertFalse("_LAMBDA_TELEMETRY_LOG_FD" in os.environ)
 
     def test_single_frame(self):
         with NamedTemporaryFile() as temp_file:
             message = "hello world\nsomething on a new line!\n"
-            with bootstrap.FramedTelemetryLogSink(temp_file.name) as ls:
+            with bootstrap.FramedTelemetryLogSink(os.open(temp_file.name, os.O_CREAT | os.O_RDWR)) as ls:
                 ls.log(message)
             with open(temp_file.name, "rb") as f:
                 content = f.read()
@@ -1101,7 +1101,7 @@ class TestLogSink(unittest.TestCase):
             first_message = "hello world\nsomething on a new line!"
             second_message = "hello again\nhere's another message\n"
 
-            with bootstrap.FramedTelemetryLogSink(temp_file.name) as ls:
+            with bootstrap.FramedTelemetryLogSink(os.open(temp_file.name, os.O_CREAT | os.O_RDWR)) as ls:
                 ls.log(first_message)
                 ls.log(second_message)
 


### PR DESCRIPTION
*Description of changes:*

Utilize the fd directly rather than through opening its pseudo file in /proc, with this change it will be more compatible with different types of file descriptor including file descriptors of network sockets, while the old approach is kinda limited to files and pipes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
