### PR TITLE
Update simplejson to 3.17.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
-simplejson==3.17.2
+simplejson==3.17.5
 importlib-metadata ~= 2.0 ; python_version < "3.8"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1151,7 +1151,7 @@ class TestBootstrapModule(unittest.TestCase):
         "awslambdaric.bootstrap.LambdaLoggerHandler",
         Mock(side_effect=Exception("Boom!")),
     )
-    @patch("awslambdaric.bootstrap.build_fault_result", MagicMock())
+    @patch("awslambdaric.bootstrap.build_fault_result", MagicMock(return_value={}))
     @patch("awslambdaric.bootstrap.log_error", MagicMock())
     @patch("awslambdaric.bootstrap.LambdaRuntimeClient", MagicMock())
     @patch("awslambdaric.bootstrap.sys")


### PR DESCRIPTION
*Description of changes:*

One test currently fails when using `simplejson` 3.17.5. I assume this is due to the one change mentioned in the [release notes](https://github.com/simplejson/simplejson/releases/tag/v3.17.5).

```
FAILED tests/test_bootstrap.py::TestBootstrapModule::test_run_exception - TypeError: _asdict() must return a dict, not MagicMock
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.