### PR TITLE
Improve Exception Output for run with Missing Handler

### DIFF
--- a/awslambdaric/__main__.py
+++ b/awslambdaric/__main__.py
@@ -10,7 +10,12 @@ from . import bootstrap
 
 def main(args):
     app_root = os.getcwd()
-    handler = args[1]
+
+    try:
+        handler = args[1]
+    except IndexError:
+        raise ValueError("Handler not set")
+
     lambda_runtime_api_addr = os.environ["AWS_LAMBDA_RUNTIME_API"]
 
     bootstrap.run(app_root, handler, lambda_runtime_api_addr)


### PR DESCRIPTION
# Summary

This change improves the error handling when running `awslambdaric` without a handler. Currently, the exception thrown is fairly non-specific: 

```
python -m awslambdaric

Traceback (most recent call last):
  File "python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "awslambdaric/__main__.py", line 20, in <module>
    main(sys.argv)
  File "awslambdaric/__main__.py", line 13, in main
    handler = args[1]
IndexError: list index out of range
```

The changes make the output a bit more human friendly 😄 :

```
python -m awslambdaric

Traceback (most recent call last):
  File "python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "awslambdaric/__main__.py", line 25, in <module>
    main(sys.argv)
  File "awslambdaric/__main__.py", line 17, in main
    raise ValueError("Handler not set")
ValueError: Handler not set
```

Even with the changes in place the module exists with an unhandled exception in the same way. We may want to wrap this to provide a more clean exit 😅 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
