### PR TITLE
Add ability to test against the support python runtimes

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,6 +20,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
+
     - name: Run 'pr' target
       run: make pr

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can include this package in your preferred base image to make that base imag
 
 ## Requirements
 The Python Runtime Interface Client package currently supports Python versions:
- - 3.6.x up to and including 3.9.x
+ - 3.6.x up to and including 3.10.x
 
 ## Usage
 
@@ -176,3 +176,4 @@ If you discover a potential security issue in this project we ask that you notif
 ## License
 
 This project is licensed under the Apache-2.0 License.
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = python3.6,python3.7,python3.8,python3.9,python3.10
+
+[testenv]
+commands =
+    make pr


### PR DESCRIPTION
*Description of changes:*
The README said we could use 3.6 -> 3.9 but it was only being tested against 3.8.   This introduces a `tox.ini` for local environment testing as well as adds a matrix for every supported python runtime in the github actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
