### PR TITLE
Remove the importlib-metadata dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,1 @@
 simplejson==3.17.2
-importlib-metadata ~= 2.0 ; python_version < "3.8"


### PR DESCRIPTION
This should complete a previous attempt to remove dependency on the
package, unblocking use of `awslambdaric` in projects that use a newer
version of `importlib-metadata`. Version 2 of `importlib-metadata` is
reasonably old - version 4.4 is present in Python 3.10 for instance.

Motivation for the change
----
I think issue #61 covers it well, but essentially it becomes difficult
to use `awslambdaric` in a virtualenv with other dependencies that
expect a newer version of `importlib-metadata`:

`awslambdaric` isn't supposed to need `importlib-metadata` anyway
----
Previous work (in August of 2021, with version 1.2.2) removed all
dependency on the `importlib-metadata` package, but accidentally left
`importlib-metadata` as a full dependency of this package:

- https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/55

Most recent version still has `importlib-metadata` dependency
-----
```
$ pip show awslambdaric
Name: awslambdaric
Version: 2.0.4
...
Requires: importlib-metadata, simplejson
```

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I've read `CONTRIBUTING.md` and believe this should be all that's needed for a PR, but please let me know if I'm missing anything!