### PR TITLE
Use unicode chars instead of escape sequences in json encoder output and bump simplejson version

### DIFF
--- a/awslambdaric/lambda_runtime_marshaller.py
+++ b/awslambdaric/lambda_runtime_marshaller.py
@@ -12,9 +12,10 @@ from .lambda_runtime_exception import FaultException
 
 # simplejson's Decimal encoding allows '-NaN' as an output, which is a parse error for json.loads
 # to get the good parts of Decimal support, we'll special-case NaN decimals and otherwise duplicate the encoding for decimals the same way simplejson does
+# We also set 'ensure_ascii=False' so that the encoded json contains unicode characters instead of unicode escape sequences
 class Encoder(json.JSONEncoder):
     def __init__(self):
-        super().__init__(use_decimal=False)
+        super().__init__(use_decimal=False, ensure_ascii=False)
 
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-simplejson==3.17.2
+simplejson==3.17.6

--- a/tests/test_lambda_runtime_marshaller.py
+++ b/tests/test_lambda_runtime_marshaller.py
@@ -37,3 +37,9 @@ class TestLambdaRuntimeMarshaller(unittest.TestCase):
         self.assertTrue(hasattr(internal_json, "YOLO"))
         self.assertFalse(hasattr(stock_json, "YOLO"))
         self.assertTrue(hasattr(simplejson, "YOLO"))
+
+    def test_to_json_unicode_encoding(self):
+        response = to_json({"price": "£1.00"})
+        self.assertEqual('{"price": "£1.00"}', response)
+        self.assertNotEqual('{"price": "\\u00a31.00"}', response)
+        self.assertEqual(19, len(response.encode('utf-8')))  # would be 23 bytes if a unicode escape was returned


### PR DESCRIPTION
Fixes #87 and Fixes #62 

Make the `Encoder` class in `lambda_runtime_marshaller` use actual unicode characters in the encoded output instead of unicode escape sequences. This matters because unicode escape sequences contribute more bytes to the response size.

Also bump simplejson version for Python 3.9 compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
