### PR TITLE
Include python 3.10 and 3.11 as supported versions

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Run 'pr' target
       run: make pr

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ setup-codebuild-agent:
 
 .PHONY: test-smoke
 test-smoke: setup-codebuild-agent
-	CODEBUILD_IMAGE_TAG=codebuild-agent tests/integration/codebuild-local/test_one.sh tests/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 3.9
+	CODEBUILD_IMAGE_TAG=codebuild-agent tests/integration/codebuild-local/test_one.sh tests/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 3.11
 
 .PHONY: test-integ
 test-integ: setup-codebuild-agent

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ We have open-sourced a set of software packages, Runtime Interface Clients (RIC)
   base images to be Lambda compatible.
 The Lambda Runtime Interface Client is a lightweight interface that allows your runtime to receive requests from and send requests to the Lambda service.
 
-The Lambda Python Runtime Interface Client is vended through [pip](https://pypi.org/project/awslambdaric). 
+The Lambda Python Runtime Interface Client is vended through [pip](https://pypi.org/project/awslambdaric).
 You can include this package in your preferred base image to make that base image Lambda compatible.
 
 ## Requirements
 The Python Runtime Interface Client package currently supports Python versions:
- - 3.7.x up to and including 3.9.x
+ - 3.7.x up to and including 3.11.x
 
 ## Usage
 
@@ -104,18 +104,18 @@ def handler(event, context):
 
 ### Local Testing
 
-To make it easy to locally test Lambda functions packaged as container images we open-sourced a lightweight web-server, Lambda Runtime Interface Emulator (RIE), which allows your function packaged as a container image to accept HTTP requests. You can install the [AWS Lambda Runtime Interface Emulator](https://github.com/aws/aws-lambda-runtime-interface-emulator) on your local machine to test your function. Then when you run the image function, you set the entrypoint to be the emulator. 
+To make it easy to locally test Lambda functions packaged as container images we open-sourced a lightweight web-server, Lambda Runtime Interface Emulator (RIE), which allows your function packaged as a container image to accept HTTP requests. You can install the [AWS Lambda Runtime Interface Emulator](https://github.com/aws/aws-lambda-runtime-interface-emulator) on your local machine to test your function. Then when you run the image function, you set the entrypoint to be the emulator.
 
 *To install the emulator and test your Lambda function*
 
-1) From your project directory, run the following command to download the RIE from GitHub and install it on your local machine. 
+1) From your project directory, run the following command to download the RIE from GitHub and install it on your local machine.
 
 ```shell script
 mkdir -p ~/.aws-lambda-rie && \
     curl -Lo ~/.aws-lambda-rie/aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie && \
     chmod +x ~/.aws-lambda-rie/aws-lambda-rie
 ```
-2) Run your Lambda image function using the docker run command. 
+2) Run your Lambda image function using the docker run command.
 
 ```shell script
 docker run -d -v ~/.aws-lambda-rie:/aws-lambda -p 9000:8080 \
@@ -124,9 +124,9 @@ docker run -d -v ~/.aws-lambda-rie:/aws-lambda -p 9000:8080 \
         /usr/local/bin/python -m awslambdaric app.handler
 ```
 
-This runs the image as a container and starts up an endpoint locally at `http://localhost:9000/2015-03-31/functions/function/invocations`. 
+This runs the image as a container and starts up an endpoint locally at `http://localhost:9000/2015-03-31/functions/function/invocations`.
 
-3) Post an event to the following endpoint using a curl command: 
+3) Post an event to the following endpoint using a curl command:
 
 ```shell script
 curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ import io
 import os
 import platform
 from subprocess import check_call, check_output
+
 from setuptools import Extension, find_packages, setup
+
 from awslambdaric import __version__
 
 
@@ -88,6 +90,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],

--- a/tests/integration/codebuild/buildspec.os.alpine.yml
+++ b/tests/integration/codebuild/buildspec.os.alpine.yml
@@ -22,6 +22,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.amazonlinux.1.yml
+++ b/tests/integration/codebuild/buildspec.os.amazonlinux.1.yml
@@ -20,6 +20,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/tests/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -20,6 +20,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.centos.yml
+++ b/tests/integration/codebuild/buildspec.os.centos.yml
@@ -20,6 +20,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.debian.yml
+++ b/tests/integration/codebuild/buildspec.os.debian.yml
@@ -21,6 +21,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/tests/integration/codebuild/buildspec.os.ubuntu.yml
@@ -21,6 +21,8 @@ batch:
             - "3.7"
             - "3.8"
             - "3.9"
+            - "3.10"
+            - "3.11"
 phases:
   pre_build:
     commands:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -585,10 +585,10 @@ class TestHandleEventRequest(unittest.TestCase):
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
-    @patch("sys.stdout", new_callable=StringIO)
     @patch("importlib.import_module")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_handle_event_request_fault_exception_logging_syntax_error(
-        self, mock_import_module, mock_stdout
+        self, mock_stdout, mock_import_module
     ):
         try:
             eval("-")
@@ -616,10 +616,17 @@ class TestHandleEventRequest(unittest.TestCase):
 
         sys.stderr.write(mock_stdout.getvalue())
 
-        error_logs = (
-            "[ERROR] Runtime.UserCodeSyntaxError: Syntax error in module 'a': "
-            "unexpected EOF while parsing (<string>, line 1)\r"
-        )
+        if sys.version_info < (3, 10):
+            error_logs = (
+                "[ERROR] Runtime.UserCodeSyntaxError: Syntax error in module 'a': "
+                "unexpected EOF while parsing (<string>, line 1)\r"
+            )
+        else:
+            error_logs = (
+                "[ERROR] Runtime.UserCodeSyntaxError: Syntax error in module 'a': "
+                "invalid syntax (<string>, line 1)\r"
+            )
+
         error_logs += "Traceback (most recent call last):\r"
         error_logs += '  File "<string>" Line 1\r'
         error_logs += "    -\n"


### PR DESCRIPTION
*Issue #89 
*Issue #85 

*Description of changes:*
Include python 3.10 and 3.11 as supported versions, adding it to the tests runtimes.  
SyntaxError error message has changed since python 3.10 that requires a change on the assertion of one the tests.

```
➜ python3.9 -c 'eval("-")'

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1
    -
    ^
SyntaxError: unexpected EOF while parsing
```
 
```
➜ python3.11 -c 'eval("-")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1
    -
SyntaxError: invalid syntax

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
