### PR TITLE
Lazily initialize http modules used for error handling

### DIFF
--- a/awslambdaric/lambda_runtime_client.py
+++ b/awslambdaric/lambda_runtime_client.py
@@ -2,8 +2,6 @@
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
-import http
-import http.client
 import sys
 from awslambdaric import __version__
 
@@ -54,6 +52,11 @@ class LambdaRuntimeClient(object):
         self.lambda_runtime_address = lambda_runtime_address
 
     def post_init_error(self, error_response_data):
+        # These imports are heavy-weight. They implicitly trigger `import ssl, hashlib`.
+        # Importing them lazily to speed up critical path of a common case.
+        import http
+        import http.client
+
         runtime_connection = http.client.HTTPConnection(self.lambda_runtime_address)
         runtime_connection.connect()
         endpoint = "/2018-06-01/runtime/init/error"


### PR DESCRIPTION
Implicit `import ssl` is happening here: https://github.com/python/cpython/blob/main/Lib/http/client.py#L1431

`http.client` is only used to report a case of thrown Exception during init. It's not a general execution path, and it's not time-critical. Thus it makes sense to speed up cold starts by importing on-demand

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
