### PR TITLE
Refactor conditional loading of ThreadPoolExecutor

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -589,10 +589,11 @@ class TestHandleEventRequest(unittest.TestCase):
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
-    @patch("sys.stdout", new_callable=StringIO)
+    # The order of patches matter. Using MagicMock resets sys.stdout to the default.
     @patch("importlib.import_module")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_handle_event_request_fault_exception_logging_syntax_error(
-        self, mock_import_module, mock_stdout
+        self, mock_stdout, mock_import_module
     ):
         try:
             eval("-")


### PR DESCRIPTION
_Description of changes:_ 
* Move ThreadPoolExecutor imports from lazy to "not as lazy". It offloads unnecessary work from actual invocations, especially the first one. Existing tests are already covering affected code paths and components
* ThreadPoolExecutor is still imported as a private dependency of a `LambdaRuntimeClient`, not exposing the symbols imported conditionally
* Fix tests - the latest runtimes have changed `unittest.mock.patch` behavior, when `sys.stdout` patching does not work as expected in certain combinations with other `@patch`'es in our testcases

_Target (OCI, Managed Runtime, both):_ Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
