### PR TITLE
Logging for failed import (of runtime_client)

### DIFF
--- a/awslambdaric/lambda_runtime_client.py
+++ b/awslambdaric/lambda_runtime_client.py
@@ -3,9 +3,15 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
 import sys
+import logging
+
 from awslambdaric import __version__
 from .lambda_runtime_exception import FaultException
 
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s",
+    level=logging.INFO,
+)
 
 def _user_agent():
     py_version = (
@@ -19,8 +25,9 @@ try:
     import runtime_client
 
     runtime_client.initialize_client(_user_agent())
-except ImportError:
-    runtime_client = None
+except ImportError as import_error:
+    logging.fatal('Failed to import "runtime_client" module. %s', import_error)
+    raise import_error
 
 from .lambda_runtime_marshaller import LambdaMarshaller
 

--- a/awslambdaric/lambda_runtime_client.py
+++ b/awslambdaric/lambda_runtime_client.py
@@ -8,11 +8,6 @@ import logging
 from awslambdaric import __version__
 from .lambda_runtime_exception import FaultException
 
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s",
-    level=logging.INFO,
-)
-
 def _user_agent():
     py_version = (
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -26,8 +21,7 @@ try:
 
     runtime_client.initialize_client(_user_agent())
 except ImportError as import_error:
-    logging.fatal('Failed to import "runtime_client" module. %s', import_error)
-    raise import_error
+    logging.fatal('Failed to import "runtime_client" cpp file. %s', import_error)
 
 from .lambda_runtime_marshaller import LambdaMarshaller
 


### PR DESCRIPTION
_Issue #, if available: #22

_Description of changes: Adding logging for failed import (due to missing libraries). Tested locally in docker via https://pip.pypa.io/en/stable/topics/vcs-support/

_Target (OCI, Managed Runtime, both): Managed Runtime

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

