### PR TITLE
Update distros in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Python Runtime Interface Client package currently supports Python versions:
 ### Creating a Docker Image for Lambda with the Runtime Interface Client
 First step is to choose the base image to be used. The supported Linux OS distributions are:
 
- - Amazon Linux 2
+ - Amazon Linux (2 and 2023)
  - Alpine
  - CentOS
  - Debian


### PR DESCRIPTION
_Description of changes:_
Update distros in README file. AWS Lambda Python3.12 runtime is using AL2023 as base OS.

_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
