### PR TITLE
Fix alpine image breaking due to missing dependencies and curl

### DIFF
--- a/tests/integration/docker/Dockerfile.echo.alpine
+++ b/tests/integration/docker/Dockerfile.echo.alpine
@@ -14,14 +14,14 @@ RUN apk add --no-cache \
 FROM python-alpine AS build-image
 # Install aws-lambda-cpp build dependencies
 RUN apk add --no-cache \
-        build-base \
-        libtool \
-        autoconf \
-        automake \
-        libexecinfo-dev \
-        make \
-        cmake \
-        libcurl
+    build-base \
+    libtool \
+    autoconf \
+    automake \
+    elfutils-dev \
+    make \
+    cmake \
+    libcurl
 
 # Include global args in this stage of the build
 ARG RIC_BUILD_DIR="/home/build/"


### PR DESCRIPTION
Context: `libexecinfo-dev` couldn't be found on alpine
Changes: replaced `libexecinfo-dev` with `elfutils`. This change is taken from the NodeJS RIC.

https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/2ce88619fd176a5823bc5f38c5484d1cbdf95717/test/integration/docker/Dockerfile.echo.alpine#L11-L22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
