### PR TITLE
Relax simplejson dependency and keep it backwards compatible

### DIFF
--- a/awslambdaric/lambda_runtime_marshaller.py
+++ b/awslambdaric/lambda_runtime_marshaller.py
@@ -16,9 +16,9 @@ from .lambda_runtime_exception import FaultException
 class Encoder(json.JSONEncoder):
     def __init__(self):
         if os.environ.get("AWS_EXECUTION_ENV") == "AWS_Lambda_python3.12":
-            super().__init__(use_decimal=False, ensure_ascii=False)
+            super().__init__(use_decimal=False, ensure_ascii=False, allow_nan=True)
         else:
-            super().__init__(use_decimal=False)
+            super().__init__(use_decimal=False, allow_nan=True)
 
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-simplejson==3.18.4
+simplejson>=3.18.4


### PR DESCRIPTION

Fixes: #147

Description of changes:

Simplejson had a breaking change from 3.18.4 (existing) going to 3.19 where the default behaviour of the JSONEncoder changed with respect to NaN handling. We address that in a backwards compatible way by passing allow_nan=True.


_Target (OCI, Managed Runtime, both):_ both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
