### PR TITLE
Propagate error type in header when reporting init error to RAPID

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -480,7 +480,7 @@ def run(app_root, handler, lambda_runtime_api_addr):
 
         if error_result is not None:
             log_error(error_result, log_sink)
-            lambda_runtime_client.post_init_error(to_json(error_result))
+            lambda_runtime_client.post_init_error(error_result)
 
             sys.exit(1)
 

--- a/awslambdaric/lambda_runtime_client.py
+++ b/awslambdaric/lambda_runtime_client.py
@@ -5,6 +5,9 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import sys
 from awslambdaric import __version__
 from .lambda_runtime_exception import FaultException
+from .lambda_runtime_marshaller import to_json
+
+ERROR_TYPE_HEADER = "Lambda-Runtime-Function-Error-Type"
 
 
 def _user_agent():
@@ -68,7 +71,10 @@ class LambdaRuntimeClient(object):
         runtime_connection = http.client.HTTPConnection(self.lambda_runtime_address)
         runtime_connection.connect()
         endpoint = "/2018-06-01/runtime/init/error"
-        runtime_connection.request("POST", endpoint, error_response_data)
+        headers = {ERROR_TYPE_HEADER: error_response_data["errorType"]}
+        runtime_connection.request(
+            "POST", endpoint, to_json(error_response_data), headers=headers
+        )
         response = runtime_connection.getresponse()
         response_body = response.read()
 


### PR DESCRIPTION
_Issue #, if available:_
NA

_Description of changes:_
Propagate error type in header when reporting init error to RAPID

_Target (OCI, Managed Runtime, both):_
Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
