### PR TITLE
Move `post_init_error` again under exception handling block

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -478,11 +478,11 @@ def run(app_root, handler, lambda_runtime_api_addr):
         except Exception:
             error_result = build_fault_result(sys.exc_info(), None)
 
-        if error_result is not None:
-            log_error(error_result, log_sink)
-            lambda_runtime_client.post_init_error(error_result)
+            if error_result is not None:
+                log_error(error_result, log_sink)
+                lambda_runtime_client.post_init_error(error_result)
 
-            sys.exit(1)
+                sys.exit(1)
 
         while True:
             event_request = lambda_runtime_client.wait_next_invocation()


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws/aws-lambda-python-runtime-interface-client/issues/172

_Description of changes:_

Move `post_init_error` again under exception handling block to preserve possibility of calling `sys.exc_info()` in monkey patched `post_init_error` function.

_Target (OCI, Managed Runtime, both):_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
