### PR TITLE
Python 3.13 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3.7
         exclude_types: ['markdown', 'ini', 'toml', 'rst']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
         exclude_types: ['markdown', 'ini', 'toml', 'rst']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black
-    rev: 19.3b0
+    rev: 24.10.0
     hooks:
       - id: black
         language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.9
         exclude_types: ['markdown', 'ini', 'toml', 'rst']

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can include this package in your preferred base image to make that base imag
 
 ## Requirements
 The Python Runtime Interface Client package currently supports Python versions:
- - 3.7.x up to and including 3.12.x
+ - 3.9.x up to and including 3.13.x
 
 ## Usage
 

--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -454,9 +454,10 @@ def run(app_root, handler, lambda_runtime_api_addr):
     sys.stdout = Unbuffered(sys.stdout)
     sys.stderr = Unbuffered(sys.stderr)
 
-    use_thread_for_polling_next = (
-        os.environ.get("AWS_EXECUTION_ENV") == "AWS_Lambda_python3.12"
-    )
+    use_thread_for_polling_next = os.environ.get("AWS_EXECUTION_ENV") in {
+        "AWS_Lambda_python3.12",
+        "AWS_Lambda_python3.13",
+    }
 
     with create_log_sink() as log_sink:
         lambda_runtime_client = LambdaRuntimeClient(

--- a/awslambdaric/lambda_runtime_marshaller.py
+++ b/awslambdaric/lambda_runtime_marshaller.py
@@ -15,7 +15,10 @@ from .lambda_runtime_exception import FaultException
 # We also set 'ensure_ascii=False' so that the encoded json contains unicode characters instead of unicode escape sequences
 class Encoder(json.JSONEncoder):
     def __init__(self):
-        if os.environ.get("AWS_EXECUTION_ENV") == "AWS_Lambda_python3.12":
+        if os.environ.get("AWS_EXECUTION_ENV") in {
+            "AWS_Lambda_python3.12",
+            "AWS_Lambda_python3.13",
+        }:
             super().__init__(use_decimal=False, ensure_ascii=False, allow_nan=True)
         else:
             super().__init__(use_decimal=False, allow_nan=True)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ pytest-cov>=2.4.0
 pylint>=1.7.2
 black>=20.8b0
 bandit>=1.6.2
+setuptools
 
 # Test requirements
 pytest>=3.0.7

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -92,7 +91,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     ext_modules=get_runtime_client_extension(),
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -93,7 +92,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     ext_modules=get_runtime_client_extension(),
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -94,7 +93,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     ext_modules=get_runtime_client_extension(),
     test_suite="tests",
 )

--- a/tests/integration/codebuild/buildspec.os.alpine.yml
+++ b/tests/integration/codebuild/buildspec.os.alpine.yml
@@ -22,6 +22,7 @@ batch:
             - "3.10"
             - "3.11"
             - "3.12"
+            - "3.13"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/tests/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -21,6 +21,7 @@ batch:
             - "3.10"
             - "3.11"
             - "3.12"
+            - "3.13"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.debian.yml
+++ b/tests/integration/codebuild/buildspec.os.debian.yml
@@ -22,6 +22,7 @@ batch:
             - "3.10"
             - "3.11"
             - "3.12"
+            - "3.13"
 phases:
   pre_build:
     commands:

--- a/tests/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/tests/integration/codebuild/buildspec.os.ubuntu.yml
@@ -22,6 +22,7 @@ batch:
             - "3.10"
             - "3.11"
             - "3.12"
+            - "3.13"
 phases:
   pre_build:
     commands:

--- a/tests/test_lambda_runtime_marshaller.py
+++ b/tests/test_lambda_runtime_marshaller.py
@@ -11,13 +11,17 @@ from awslambdaric.lambda_runtime_marshaller import to_json
 
 class TestLambdaRuntimeMarshaller(unittest.TestCase):
     execution_envs = (
+        "AWS_Lambda_python3.13",
         "AWS_Lambda_python3.12",
         "AWS_Lambda_python3.11",
         "AWS_Lambda_python3.10",
         "AWS_Lambda_python3.9",
     )
 
-    envs_lambda_marshaller_ensure_ascii_false = {"AWS_Lambda_python3.12"}
+    envs_lambda_marshaller_ensure_ascii_false = {
+        "AWS_Lambda_python3.12",
+        "AWS_Lambda_python3.13",
+    }
 
     execution_envs_lambda_marshaller_ensure_ascii_true = tuple(
         set(execution_envs).difference(envs_lambda_marshaller_ensure_ascii_false)


### PR DESCRIPTION
_Issue #, if available:_ #173

_Description of changes:_ Added support for Python 3.13 and removed support for the EOL versions 3.6, 3.7 and 3.8.

_Target (OCI, Managed Runtime, both):_ Both, I guess?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
