### PR TITLE
Remove simplejson dependency

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -204,30 +204,6 @@ limitations under the License.
 
 ------
 
-** python-simplejson; version 3.17.2 --
-https://github.com/simplejson/simplejson
-Copyright (c) 2006 Bob Ippolito
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------
-
 ** libcurl; version 7.83.1 -- https://github.com/curl/curl
 Copyright (c) 1996 - 2022, Daniel Stenberg, daniel@haxx.se, and many
 contributors, see the THANKS file.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,1 @@
-simplejson>=3.20.1
 snapshot-restore-py>=1.0.0

--- a/tests/test_lambda_runtime_marshaller.py
+++ b/tests/test_lambda_runtime_marshaller.py
@@ -48,23 +48,6 @@ class TestLambdaRuntimeMarshaller(unittest.TestCase):
         response = to_json({"pi": decimal.Decimal("-nan")})
         self.assertEqual('{"pi": NaN}', response)
 
-    def test_json_serializer_is_not_default_json(self):
-        from awslambdaric.lambda_runtime_marshaller import (
-            json as internal_json,
-        )
-        import simplejson as simplejson
-        import json as stock_json
-        import json
-
-        self.assertEqual(json, stock_json)
-        self.assertNotEqual(stock_json, internal_json)
-        self.assertNotEqual(stock_json, simplejson)
-
-        internal_json.YOLO = "bello"
-        self.assertTrue(hasattr(internal_json, "YOLO"))
-        self.assertFalse(hasattr(stock_json, "YOLO"))
-        self.assertTrue(hasattr(simplejson, "YOLO"))
-
     @parameterized.expand(execution_envs_lambda_marshaller_ensure_ascii_false)
     def test_to_json_unicode_not_escaped_encoding(self, execution_env):
         os.environ = {"AWS_EXECUTION_ENV": execution_env}


### PR DESCRIPTION
When simplejson is installed, `requests` behaves differently https://github.com/psf/requests/blob/1764cc938efc3cc9720188dfa6c3852c45211aa0/src/requests/compat.py#L59-L64 which affects custom JSONEncode/Decoders

Instead of relying on simplejson for decimal support implement decimal support directly

Remove the `internal_json` vs `stock_json` test comparison

_Issue #, if available:_

_Description of changes:_

_Target (OCI, Managed Runtime, both):_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
