### PR TITLE
Move unhandled exception warning message to init errors.

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -201,9 +201,7 @@ def handle_event_request(
         )
 
     if error_result is not None:
-        from .lambda_literals import lambda_unhandled_exception_warning_message
 
-        logging.warning(lambda_unhandled_exception_warning_message)
         log_error(error_result, log_sink)
         lambda_runtime_client.post_invocation_error(
             invoke_id, to_json(error_result), to_json(xray_fault)
@@ -509,6 +507,9 @@ def run(app_root, handler, lambda_runtime_api_addr):
             error_result = build_fault_result(sys.exc_info(), None)
 
         if error_result is not None:
+            from .lambda_literals import lambda_unhandled_exception_warning_message
+
+            logging.warning(lambda_unhandled_exception_warning_message)
             log_error(error_result, log_sink)
             lambda_runtime_client.post_init_error(error_result)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -489,11 +489,7 @@ class TestHandleEventRequest(unittest.TestCase):
         )
 
         # NOTE: Indentation characters are NO-BREAK SPACE (U+00A0) not SPACE (U+0020)
-        error_logs = (
-            lambda_unhandled_exception_warning_message
-            + "\n"
-            + "[ERROR] FaultExceptionType: Fault exception msg\r"
-        )
+        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\r"
         error_logs += "Traceback (most recent call last):\r"
         error_logs += '  File "spam.py", line 3, in <module>\r'
         error_logs += "    spam.eggs()\r"
@@ -527,11 +523,7 @@ class TestHandleEventRequest(unittest.TestCase):
             "tenant_id",
             bootstrap.StandardLogSink(),
         )
-        error_logs = (
-            lambda_unhandled_exception_warning_message
-            + "\n"
-            + "[ERROR] FaultExceptionType: Fault exception msg\rTraceback (most recent call last):\n"
-        )
+        error_logs = "[ERROR] FaultExceptionType: Fault exception msg\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -560,11 +552,7 @@ class TestHandleEventRequest(unittest.TestCase):
             "tenant_id",
             bootstrap.StandardLogSink(),
         )
-        error_logs = (
-            lambda_unhandled_exception_warning_message
-            + "\n"
-            + "[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
-        )
+        error_logs = "[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -593,11 +581,7 @@ class TestHandleEventRequest(unittest.TestCase):
             "tenant_id",
             bootstrap.StandardLogSink(),
         )
-        error_logs = (
-            lambda_unhandled_exception_warning_message
-            + "\n"
-            + "[ERROR] Fault exception msg\rTraceback (most recent call last):\n"
-        )
+        error_logs = "[ERROR] Fault exception msg\rTraceback (most recent call last):\n"
 
         self.assertEqual(mock_stdout.getvalue(), error_logs)
 
@@ -635,7 +619,7 @@ class TestHandleEventRequest(unittest.TestCase):
             "tenant_id",
             bootstrap.StandardLogSink(),
         )
-        error_logs = lambda_unhandled_exception_warning_message + "\n[ERROR]\r"
+        error_logs = "[ERROR]\r"
         error_logs += "Traceback (most recent call last):\r"
         error_logs += '  File "spam.py", line 3, in <module>\r'
         error_logs += "    spam.eggs()\r"
@@ -671,21 +655,11 @@ class TestHandleEventRequest(unittest.TestCase):
         )
 
         stdout_value = mock_stdout.getvalue()
-        received_warning = stdout_value.split("\n")[0]
-        received_rest = stdout_value[len(received_warning) + 1 :]
-
-        warning = json.loads(received_warning)
-        self.assertEqual(warning["level"], "WARNING")
-        self.assertEqual(warning["message"], lambda_unhandled_exception_warning_message)
-        self.assertEqual(warning["logger"], "root")
-        self.assertIn("timestamp", warning)
 
         # this line is not in json because of the way the test runtime is bootstrapped
-        error_logs = (
-            "\n[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
-        )
+        error_logs = "[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
 
-        self.assertEqual(received_rest, error_logs)
+        self.assertEqual(stdout_value, error_logs)
 
 
 class TestXrayFault(unittest.TestCase):


### PR DESCRIPTION
_Issue #, if available:_

N/a 

_Description of changes:_

- Move warning message to appear only on init errors.

_Target (OCI, Managed Runtime, both):_

Managed Runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
