### PR TITLE
fix: disable ngtcp2/nghttp3 in curl build to fix amazonlinux2023 CI

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -37,7 +37,9 @@ else
                 --disable-shared \
                 --without-ssl \
                 --with-pic \
-                --without-zlib && \
+                --without-zlib \
+                --without-ngtcp2 \
+                --without-nghttp3 && \
             make && \
             make install
     )


### PR DESCRIPTION
- Adds --without-ngtcp2 and --without-nghttp3 to the curl ./configure step in scripts/preinstall.sh
 - Fixes the amazonlinux integration test failure in CI

Amazon Linux 2023's libcurl-devel package now transitively installs ngtcp2-devel 1.21.0. When the bundled curl 7.83.1 runs ./configure, it auto-detects the system ngtcp2 headers and attempts to compile HTTP/3 (QUIC) support. However, curl 7.83.1 was written against an older ngtcp2 API, causing compilation errors like:
```
  vquic/ngtcp2.c:165:6: error: 'ngtcp2_settings' has no member named 'qlog'
  vquic/ngtcp2.c:195:35: error: unknown type name 'ngtcp2_crypto_level'
  vquic/ngtcp2.c:902:3: error: unknown type name 'ngtcp2_connection_close_error'
```
  **Fix:** Explicitly disable HTTP/3 dependencies at configure time. The RIC only needs basic HTTP to communicate with the Lambda Runtime API QUIC/HTTP3 support is unnecessary.

_Target (OCI, Managed Runtime, both):_
both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
