### PR TITLE
Add preview warning for Python 3.15

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -33,6 +33,7 @@ _AWS_LAMBDA_LOG_LEVEL = _get_log_level_from_env_var(
 )
 AWS_LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE"
 INIT_TYPE_SNAP_START = "snap-start"
+PREVIEW_RUNTIME_ENVS = {"AWS_Lambda_python3.15"}
 
 
 def _get_handler(handler):
@@ -477,6 +478,18 @@ def _setup_logging(log_format, log_level, log_sink):
     logger.addHandler(logger_handler)
 
 
+def _log_preview_runtime_warning():
+    """Emit a warning if the runtime version is a preview."""
+    if os.environ.get("LAMBDA_DISABLE_PREVIEW_WARN", ""):
+        return
+
+    from .lambda_literals import get_lambda_preview_runtime_warning_message
+
+    execution_env = os.environ.get("AWS_EXECUTION_ENV", "")
+    if execution_env in PREVIEW_RUNTIME_ENVS:
+        logging.warning(get_lambda_preview_runtime_warning_message())
+
+
 def run(handler, lambda_runtime_client):
     sys.stdout = Unbuffered(sys.stdout)
     sys.stderr = Unbuffered(sys.stderr)
@@ -487,6 +500,8 @@ def run(handler, lambda_runtime_client):
         try:
             _setup_logging(_AWS_LAMBDA_LOG_FORMAT, _AWS_LAMBDA_LOG_LEVEL, log_sink)
             global _GLOBAL_AWS_REQUEST_ID, _GLOBAL_TENANT_ID
+
+            _log_preview_runtime_warning()
 
             request_handler = _get_handler(handler)
         except FaultException as e:

--- a/awslambdaric/lambda_config.py
+++ b/awslambdaric/lambda_config.py
@@ -10,6 +10,7 @@ class LambdaConfigProvider:
         "AWS_Lambda_python3.12",
         "AWS_Lambda_python3.13",
         "AWS_Lambda_python3.14",
+        "AWS_Lambda_python3.15",
     }
     SOCKET_PATH_ENV = "_LAMBDA_TELEMETRY_LOG_FD_PROVIDER_SOCKET"
     AWS_LAMBDA_RUNTIME_API = "AWS_LAMBDA_RUNTIME_API"

--- a/awslambdaric/lambda_literals.py
+++ b/awslambdaric/lambda_literals.py
@@ -4,6 +4,29 @@ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 lambda_warning = "LAMBDA_WARNING"
 
+_PREVIEW_DOC_LINK = "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+_PREVIEW_DOC_LINK_CN = "https://docs.amazonaws.cn/lambda/latest/dg/lambda-runtimes.html"
+
+
+def _get_preview_doc_link():
+    import os
+
+    region = os.environ.get("AWS_REGION", "")
+    if region.startswith("cn-"):
+        return _PREVIEW_DOC_LINK_CN
+    return _PREVIEW_DOC_LINK
+
+
+# Holds warning message that is emitted when the runtime is a preview version.
+def get_lambda_preview_runtime_warning_message():
+    return str(
+        f"{lambda_warning}: "
+        "This is a preview runtime version and should not be used for production workloads. "
+        "For further information and to provide feedback, see "
+        f"{_get_preview_doc_link()}\r"
+    )
+
+
 # Holds warning message that is emitted when an unhandled exception is raised during function invocation.
 lambda_unhandled_exception_warning_message = str(
     f"{lambda_warning}: "

--- a/awslambdaric/lambda_runtime_marshaller.py
+++ b/awslambdaric/lambda_runtime_marshaller.py
@@ -19,6 +19,7 @@ class Encoder(json.JSONEncoder):
             "AWS_Lambda_python3.12",
             "AWS_Lambda_python3.13",
             "AWS_Lambda_python3.14",
+            "AWS_Lambda_python3.15",
         }:
             super().__init__(use_decimal=False, ensure_ascii=False, allow_nan=True)
         else:

--- a/tests/test_lambda_runtime_marshaller.py
+++ b/tests/test_lambda_runtime_marshaller.py
@@ -11,6 +11,7 @@ from awslambdaric.lambda_runtime_marshaller import to_json
 
 class TestLambdaRuntimeMarshaller(unittest.TestCase):
     execution_envs = (
+        "AWS_Lambda_python3.15",
         "AWS_Lambda_python3.14",
         "AWS_Lambda_python3.13",
         "AWS_Lambda_python3.12",
@@ -23,6 +24,7 @@ class TestLambdaRuntimeMarshaller(unittest.TestCase):
         "AWS_Lambda_python3.12",
         "AWS_Lambda_python3.13",
         "AWS_Lambda_python3.14",
+        "AWS_Lambda_python3.15",
     }
 
     execution_envs_lambda_marshaller_ensure_ascii_true = tuple(


### PR DESCRIPTION
_Issue #, if available:_ none

_Description of changes:_ This change adds a message meant to warn that the Lambda function is running on top of a preview runtime. The message can be disabled via the env variable `LAMBDA_DISABLE_PREVIEW_WARN`

_Target (OCI, Managed Runtime, both):_ both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
