### PR TITLE
chore(release): 4.0.1

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -1,0 +1,63 @@
+name: release-on-version-change
+
+# Creates a GitHub Release automatically whenever the package version in
+# awslambdaric/__init__.py changes on main. The release notes are taken from
+# the matching section of RELEASE.CHANGELOG.md.
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'awslambdaric/__init__.py'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION="$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' awslambdaric/__init__.py)"
+          if [ -z "$VERSION" ]; then
+            echo "Could not determine version from awslambdaric/__init__.py" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Extract changelog notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Write notes to a file (never interpolated into the shell) so that
+          # special characters in the changelog (backticks, parentheses, etc.)
+          # are passed verbatim to gh via --notes-file.
+          awk -v ver="$VERSION" '
+            index($0, "`" ver "`") == 1 { capture = 1; next }
+            capture && /^### / { exit }
+            capture { print }
+          ' RELEASE.CHANGELOG.md > release-notes.md
+          # Trim leading blank lines.
+          sed -i -e '/./,$!d' release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog entry found for $VERSION in RELEASE.CHANGELOG.md." >&2
+            echo "Add a '\`$VERSION\`' section before bumping the version." >&2
+            exit 1
+          fi
+          echo "----- release notes -----"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "AWS Lambda Runtime Interface Client for Python v$VERSION" \
+            --notes-file release-notes.md \
+            --latest

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### June 25, 2026
+`4.0.1`
+- Support building on Alpine Linux 3.17+ (musl) without `libexecinfo-dev` ([#204](https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/204))
+- Lazy load `multi_concurrent_utils` ([#211](https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/211))
+
 ### Feb 20, 2026
 `4.0.0`
 - Add Lambda Managed Instances (LMI) / Multi-Concurrent Support ([#200](https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/200))

--- a/awslambdaric/__init__.py
+++ b/awslambdaric/__init__.py
@@ -2,4 +2,4 @@
 Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"


### PR DESCRIPTION
## Summary
Release `4.0.1` of the AWS Lambda Python Runtime Interface Client, plus release automation.

Bumps the version from `4.0.0` to `4.0.1`, adds the changelog entry, and adds a workflow to auto-create GitHub Releases on future version bumps.

## Release content
- Support building on Alpine Linux 3.17+ (musl) without `libexecinfo-dev` (#204)
- Lazy load `multi_concurrent_utils` (#211)

## Changes
- `awslambdaric/__init__.py`: `__version__` 4.0.0 → 4.0.1
- `RELEASE.CHANGELOG.md`: added `4.0.1` entry
- `.github/workflows/release-on-version-change.yml`: new workflow that, on push to `main` touching `awslambdaric/__init__.py`, creates a tag + GitHub Release (titled `AWS Lambda Runtime Interface Client for Python v<version>`) with notes pulled from the matching `RELEASE.CHANGELOG.md` section. Skips if a release for that version already exists.

## Notes
- The workflow uses the built-in `GITHUB_TOKEN` with `contents: write` (scoped to this job only).
- On merge of this PR, the version change will trigger the workflow and publish the `4.0.1` release automatically.
- Rebased onto latest `main` (includes #204 and #211).

## Testing
- Version/changelog change only beyond the already-merged fixes (#204, #211). Version-extraction and changelog-notes parsing were validated locally; workflow YAML validated. CI on this PR runs the build and integration-test matrix.