### PR TITLE
Lazy load multi-concurrent utilities for cold start improvement

### DIFF
--- a/awslambdaric/__main__.py
+++ b/awslambdaric/__main__.py
@@ -6,7 +6,6 @@ import sys
 
 from .lambda_config import LambdaConfigProvider
 from .lambda_runtime_client import LambdaRuntimeClient
-from .lambda_multi_concurrent_utils import MultiConcurrentRunner
 from . import bootstrap
 
 
@@ -20,6 +19,10 @@ def main(args):
         # Multi-concurrent mode: redirect fork, stdout/stderr and run
         max_conc = int(config.max_concurrency)
         socket_path = config.lmi_socket_path
+
+        # Importing multi_concurrent_utils only in the multiconcurrent path
+        from .lambda_multi_concurrent_utils import MultiConcurrentRunner
+
         MultiConcurrentRunner.run_concurrent(
             handler, api_addr, use_thread, socket_path, max_conc
         )

--- a/awslambdaric/__main__.py
+++ b/awslambdaric/__main__.py
@@ -20,7 +20,6 @@ def main(args):
         max_conc = int(config.max_concurrency)
         socket_path = config.lmi_socket_path
 
-        # Importing multi_concurrent_utils only in the multiconcurrent path
         from .lambda_multi_concurrent_utils import MultiConcurrentRunner
 
         MultiConcurrentRunner.run_concurrent(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,7 @@ class TestMain(unittest.TestCase):
             "my.handler", mock_client_cls.return_value
         )
 
-    @patch("awslambdaric.__main__.MultiConcurrentRunner")
+    @patch("awslambdaric.lambda_multi_concurrent_utils.MultiConcurrentRunner")
     @patch("awslambdaric.__main__.LambdaConfigProvider")
     def test_multi_concurrent_path_dispatches_to_multi_concurrent_runner(
         self, mock_config_provider, mock_runner

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,11 +9,12 @@ import awslambdaric.__main__ as package_entry
 
 
 class TestMain(unittest.TestCase):
+    @patch("awslambdaric.lambda_multi_concurrent_utils.MultiConcurrentRunner")
     @patch("awslambdaric.__main__.bootstrap")
     @patch("awslambdaric.__main__.LambdaRuntimeClient")
     @patch("awslambdaric.__main__.LambdaConfigProvider")
     def test_default_path_invokes_runtime_client_and_bootstrap(
-        self, mock_config_provider, mock_client_cls, mock_bootstrap
+        self, mock_config_provider, mock_client_cls, mock_bootstrap, mock_runner
     ):
         # Non-multi-concurrent mode
         cfg = MagicMock()
@@ -29,6 +30,8 @@ class TestMain(unittest.TestCase):
         mock_bootstrap.run.assert_called_once_with(
             "my.handler", mock_client_cls.return_value
         )
+
+        mock_runner.run_concurrent.assert_not_called()
 
     @patch("awslambdaric.lambda_multi_concurrent_utils.MultiConcurrentRunner")
     @patch("awslambdaric.__main__.LambdaConfigProvider")


### PR DESCRIPTION
_Issue #, if available:_

N/A

_Description of changes:_

Lazy load `lambda_multi_concurrent_utils` to avoid importing `multiprocessing` and `socket` at module load time for the standard (single-invoke) Lambda execution path. This reduces cold start overhead when multi-concurrent mode is not in use.

Changes:
- Moved `from .lambda_multi_concurrent_utils import MultiConcurrentRunner` from top-level import to inside the `if config.is_multi_concurrent:` branch in `__main__.py`
- Bumped version to `4.0.1`
- Added changelog entry

_Target (OCI, Managed Runtime, both):_

Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
