### PR TITLE
Switch thread polling to a denylist with OCI version fallback

### DIFF
--- a/awslambdaric/lambda_config.py
+++ b/awslambdaric/lambda_config.py
@@ -3,15 +3,16 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
 import os
+import sys
 
 
 class LambdaConfigProvider:
-    SUPPORTED_THREADPOLLING_ENVS = {
-        "AWS_Lambda_python3.12",
-        "AWS_Lambda_python3.13",
-        "AWS_Lambda_python3.14",
-        "AWS_Lambda_python3.15",
+    UNSUPPORTED_THREADPOLLING_ENVS = {
+        "AWS_Lambda_python3.9",
+        "AWS_Lambda_python3.10",
+        "AWS_Lambda_python3.11",
     }
+
     SOCKET_PATH_ENV = "_LAMBDA_TELEMETRY_LOG_FD_PROVIDER_SOCKET"
     AWS_LAMBDA_RUNTIME_API = "AWS_LAMBDA_RUNTIME_API"
     AWS_LAMBDA_MAX_CONCURRENCY = "AWS_LAMBDA_MAX_CONCURRENCY"
@@ -40,7 +41,7 @@ class LambdaConfigProvider:
     def _parse_thread_polling(self):
         return (
             self._environ.get(self.AWS_EXECUTION_ENV)
-            in self.SUPPORTED_THREADPOLLING_ENVS
+            not in self.UNSUPPORTED_THREADPOLLING_ENVS
         )
 
     def _parse_lmi_socket_path(self):

--- a/tests/test_lambda_config.py
+++ b/tests/test_lambda_config.py
@@ -3,6 +3,7 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
 import os
+import sys
 import unittest
 from awslambdaric.lambda_config import LambdaConfigProvider
 
@@ -41,16 +42,45 @@ class TestLambdaConfigProvider(unittest.TestCase):
         self.assertIsNone(cfg2.max_concurrency)
         self.assertFalse(cfg2.is_multi_concurrent)
 
-    def test_use_thread_polling_flag(self):
+    def test_use_thread_polling_disabled_for_unsupported_managed_envs(self):
+        # Managed runtimes on the denylist never use thread polling,
+        # regardless of the Python version the code happens to run on.
+        for exec_env in LambdaConfigProvider.UNSUPPORTED_THREADPOLLING_ENVS:
+            env = {
+                "AWS_LAMBDA_RUNTIME_API": "a",
+                "AWS_EXECUTION_ENV": exec_env,
+            }
+            cfg = LambdaConfigProvider(["p", "h.fn"], environ=env)
+            self.assertFalse(
+                cfg.use_thread_polling,
+                msg=f"expected thread polling disabled for {exec_env}",
+            )
+
+    def test_use_thread_polling_enabled_for_custom_oci_image(self):
+        # Custom OCI images (AWS_Lambda_Image) are not on the denylist and
+        # fall back to the minimum-supported Python version check.
+        env = {
+            "AWS_LAMBDA_RUNTIME_API": "a",
+            "AWS_EXECUTION_ENV": "AWS_Lambda_Image",
+        }
+        cfg = LambdaConfigProvider(["p", "h.fn"], environ=env)
+        self.assertEqual(cfg.use_thread_polling, sys.version_info >= (3, 4))
+
+    def test_use_thread_polling_enabled_for_supported_managed_env(self):
+        # Managed runtimes not on the denylist (e.g. newer versions) fall
+        # back to the Python version check.
         env = {
             "AWS_LAMBDA_RUNTIME_API": "a",
             "AWS_EXECUTION_ENV": "AWS_Lambda_python3.12",
         }
         cfg = LambdaConfigProvider(["p", "h.fn"], environ=env)
-        self.assertTrue(cfg.use_thread_polling)
-        env2 = {"AWS_LAMBDA_RUNTIME_API": "a", "AWS_EXECUTION_ENV": "OTHER"}
-        cfg2 = LambdaConfigProvider(["p", "h.fn"], environ=env2)
-        self.assertFalse(cfg2.use_thread_polling)
+        self.assertEqual(cfg.use_thread_polling, sys.version_info >= (3, 4))
+
+    def test_use_thread_polling_without_execution_env(self):
+        # With no AWS_EXECUTION_ENV set, fall back to the version check.
+        env = {"AWS_LAMBDA_RUNTIME_API": "a"}
+        cfg = LambdaConfigProvider(["p", "h.fn"], environ=env)
+        self.assertEqual(cfg.use_thread_polling, sys.version_info >= (3, 4))
 
     def test_lmi_socket_path_property(self):
         env = {


### PR DESCRIPTION
_Issue #, if available:_ #105 

_Description of changes:_

This change enables graceful shutdown hooks for custom OCI images (when AWS_EXECUTION_ENV is not defined the default is AWS_Lambda_Image) as long as the Python version is high enough for the thread pool to exist.

Also fewer stuff to maintain since we're turning it into a denylist 🎉 

_Target (OCI, Managed Runtime, both):_ both


_Testing_: 

Dockerfile.python310
```
# Python 3.10 Lambda container image using AWS Lambda base image
FROM public.ecr.aws/lambda/python:3.10 AS build-image

# Install build dependencies
RUN yum install -y \
    gcc \
    gcc-c++ \
    make \
    cmake3 \
    libcurl-devel \
    autoconf \
    automake \
    libtool \
    tar \
    gzip \
    && ln -sf /usr/bin/cmake3 /usr/bin/cmake \
    && yum clean all

# Build the runtime interface client from local source
ARG RIC_BUILD_DIR="/home/build/"
RUN mkdir -p ${RIC_BUILD_DIR}
WORKDIR ${RIC_BUILD_DIR}
COPY . .

RUN pip install setuptools
RUN make init build
RUN mv ./dist/awslambdaric-*.tar.gz ./dist/awslambdaric-test.tar.gz

# Copy the function handler
ARG FUNCTION_DIR="/var/task"
RUN mkdir -p ${FUNCTION_DIR}
COPY tests/integration/test-handlers/shutdown-hook/* ${FUNCTION_DIR}


# Final stage - clean runtime image
FROM public.ecr.aws/lambda/python:3.10

ARG FUNCTION_DIR="/var/task"
WORKDIR ${FUNCTION_DIR}

# Copy the function code
COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}

# Copy the built RIC tarball and install it, overriding the bundled awslambdaric in /var/runtime
COPY --from=build-image /home/build/dist/awslambdaric-test.tar.gz /tmp/
RUN yum install -y gcc gcc-c++ make cmake3 libcurl-devel tar gzip autoconf automake libtool && \
    ln -sf /usr/bin/cmake3 /usr/bin/cmake && \
    rm -rf /var/runtime/awslambdaric* && \
    rm -f /var/runtime/runtime_client* && \
    pip install /tmp/awslambdaric-test.tar.gz --target /var/runtime && \
    rm /tmp/awslambdaric-test.tar.gz && \
    yum history undo -y last && yum clean all && rm -rf /var/cache/yum

# Install Lambda Insights extension layer (required for graceful shutdown support)
# Download manually before building:
# curl -f -s -o lambda-insights-amd64-64.zip "$(aws lambda get-layer-version-by-arn --region eu-west-1 --arn "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:64" --query 'Content.Location' --output text)"
COPY lambda-insights-amd64-64.zip /tmp
# hadolint ignore=DL3033
RUN yum install -y unzip && unzip -q -d /opt /tmp/lambda-insights-amd64-64.zip && rm /tmp/*.zip && \
    yum history undo -y last && yum clean all && rm -rf /var/cache/yum

# Replace AWS_EXECUTION_ENV so the base image's bundled RIC path isn't triggered
RUN sed -i 's/export AWS_EXECUTION_ENV=.*/export AWS_EXECUTION_ENV=AWS_Lambda_Image/' /var/runtime/bootstrap

CMD [ "app.lambda_handler" ]
```

Handler (tests/integration/test-handlers/shutdown-hook/app.py) - same as the official demo

```
import json
import platform
import signal
import sys
import time


def exit_gracefully(signum, frame):
    r"""
    SIGTERM Handler: https://docs.aws.amazon.com/lambda/latest/operatorguide/static-initialization.html
    Listening for os signals that can be handled,reference: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
    Termination Signals: https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html
    """
    print("[runtime] SIGTERM received")

    print("[runtime] cleaning up")
    # perform actual clean up work here.
    time.sleep(0.2)

    print("[runtime] exiting")
    sys.exit(0)


signal.signal(signal.SIGTERM, exit_gracefully)


def lambda_handler(event, context):
    return "SUCCESS"
```


Cloudwatch logs Python 3.10
```
2026-07-02T17:51:39.669+01:00	LOGS Name: cloudwatch_lambda_agent State: Subscribed Types: [Platform]	
	2026-07-02T17:51:40.201+01:00	EXTENSION Name: cloudwatch_lambda_agent State: Ready Events: [INVOKE, SHUTDOWN]
	2026-07-02T17:51:40.208+01:00	START RequestId: be18ce5e-0ef9-4933-917f-ebfc53522ab7 Version: $LATEST
	2026-07-02T17:51:40.218+01:00	END RequestId: be18ce5e-0ef9-4933-917f-ebfc53522ab7
	2026-07-02T17:51:40.218+01:00	REPORT RequestId: be18ce5e-0ef9-4933-917f-ebfc53522ab7 Duration: 3.36 ms Billed Duration: 642 ms Memory Size: 512 MB Max Memory Used: 39 MB Init Duration: 637.70 ms
	2026-07-02T17:57:39.206+01:00	[runtime] SIGTERM received
	2026-07-02T17:57:39.206+01:00	[runtime] cleaning up
	2026-07-02T17:57:39.406+01:00	[runtime] exiting
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

