### PR TITLE
fix: call post_init_error within init exception handling block

### DIFF
--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -495,8 +495,6 @@ def run(handler, lambda_runtime_client):
     sys.stderr = Unbuffered(sys.stderr)
 
     with create_log_sink() as log_sink:
-        error_result = None
-
         try:
             _setup_logging(_AWS_LAMBDA_LOG_FORMAT, _AWS_LAMBDA_LOG_LEVEL, log_sink)
             global _GLOBAL_AWS_REQUEST_ID, _GLOBAL_TENANT_ID
@@ -504,20 +502,24 @@ def run(handler, lambda_runtime_client):
             _log_preview_runtime_warning()
 
             request_handler = _get_handler(handler)
-        except FaultException as e:
-            error_result = make_error(
-                e.msg,
-                e.exception_type,
-                e.trace,
-            )
-        except Exception:
-            error_result = build_fault_result(sys.exc_info(), None)
+        except Exception as e:
+            if isinstance(e, FaultException):
+                error_result = make_error(
+                    e.msg,
+                    e.exception_type,
+                    e.trace,
+                )
+            else:
+                error_result = build_fault_result(sys.exc_info(), None)
 
-        if error_result is not None:
             from .lambda_literals import lambda_unhandled_exception_warning_message
 
             logging.warning(lambda_unhandled_exception_warning_message)
             log_error(error_result, log_sink)
+            # post_init_error must be called within the exception handling block
+            # so that the init error being handled is still accessible via
+            # sys.exc_info() (e.g. APM tools such as Sentry monkey-patch
+            # post_init_error and rely on this). See issue #172.
             lambda_runtime_client.post_init_error(error_result)
 
             sys.exit(1)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import os
 import re
+import sys
 import tempfile
 import time
 import traceback
@@ -1535,6 +1536,60 @@ class TestBootstrapModule(unittest.TestCase):
             bootstrap.run(expected_handler, mock_runtime_client)
 
         mock_sys.exit.assert_called_once_with(1)
+
+    def test_run_fault_exception_post_init_error_within_exception_context(self):
+        # Regression test for GitHub issue #172: post_init_error must be
+        # invoked while the init error is still being handled so that
+        # monkey-patched implementations (e.g. Sentry SDK) can access the
+        # exception through sys.exc_info().
+        expected_handler = "app.my_test_handler"
+
+        captured_exc_info = []
+
+        def capture_exc_info(*args, **kwargs):
+            captured_exc_info.append(sys.exc_info())
+
+        mock_runtime_client = MagicMock()
+        mock_runtime_client.post_init_error.side_effect = capture_exc_info
+
+        with self.assertRaises(SystemExit) as cm:
+            bootstrap.run(expected_handler, mock_runtime_client)
+
+        self.assertEqual(cm.exception.code, 1)
+        mock_runtime_client.post_init_error.assert_called_once()
+
+        etype, value, tb = captured_exc_info[0]
+        self.assertIs(etype, FaultException)
+        self.assertIsNotNone(value)
+        self.assertIsNotNone(tb)
+
+    @patch(
+        "awslambdaric.bootstrap.LambdaLoggerHandler",
+        Mock(side_effect=Exception("Boom!")),
+    )
+    @patch("awslambdaric.bootstrap.log_error", MagicMock())
+    def test_run_generic_exception_post_init_error_within_exception_context(self):
+        # Same as above, but for the non-FaultException init error path.
+        expected_handler = "app.my_test_handler"
+
+        captured_exc_info = []
+
+        def capture_exc_info(*args, **kwargs):
+            captured_exc_info.append(sys.exc_info())
+
+        mock_runtime_client = MagicMock()
+        mock_runtime_client.post_init_error.side_effect = capture_exc_info
+
+        with self.assertRaises(SystemExit) as cm:
+            bootstrap.run(expected_handler, mock_runtime_client)
+
+        self.assertEqual(cm.exception.code, 1)
+        mock_runtime_client.post_init_error.assert_called_once()
+
+        etype, value, tb = captured_exc_info[0]
+        self.assertIs(etype, Exception)
+        self.assertEqual(str(value), "Boom!")
+        self.assertIsNotNone(tb)
 
 
 class TestOnInitComplete(unittest.TestCase):


### PR DESCRIPTION
Restores sys.exc_info() access for tools that monkey-patch post_init_error (e.g. Sentry SDK). The init error paths are merged into a single except block that type-checks FaultException, keeping error reporting behavior identical for both paths.

Fixes #172

_Description of changes:_

PR #163 moved the `post_init_error` call in `bootstrap.run()` outside the `except` blocks. Since Python clears the handled exception once an `except` block exits, `sys.exc_info()` returns `(None, None, None)` by the time `post_init_error` runs. This broke APM tools such as the Sentry SDK, which monkey-patch `post_init_error` and rely on `sys.exc_info()` to capture init errors (see #172).

An earlier community fix (#171) was closed because it moved the call under only one of the two `except` clauses, which would have dropped error reporting for the `FaultException` path. This PR implements the alternative suggested by the maintainer in the #171 review discussion:

- Merge the two `except` clauses in `run()` into a single `except Exception` block that type-checks for `FaultException`, so `error_result` is built exactly as before for both paths.
- Call `post_init_error` (and `sys.exit(1)`) inside the `except` block, restoring `sys.exc_info()` availability while keeping error reporting behavior identical.
- Add a code comment referencing #172 to guard against future regressions.
- Add two regression tests that capture `sys.exc_info()` inside a mocked `post_init_error` and assert the active exception is visible: one for the `FaultException` path (bad handler) and one for the generic exception path.

No behavior change otherwise: both exception types still log the unhandled-exception warning, report the error via `post_init_error`, and exit with code 1. `on_init_complete()` already calls `post_init_error` inside its `except` block, so no change was needed there.

Tested with `make test`: 126 tests pass, coverage 95% (gate is 90%), `black --check` clean.

_Target (OCI, Managed Runtime, both):_ both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

