### PR TITLE
feat: Emit worker pool size as a DEBUG log event during init on Lambda Managed Instances

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### September 2, 2026
+`4.0.3`
+- Emit a structured `runtime_worker_pool_initializing` DEBUG log event once per execution environment during INIT in multi-concurrent (Lambda Managed Instances) mode, reporting `workerCount` and `executionEnvironmentMaxConcurrency` for worker pool observability. Only visible when the function log level is DEBUG or lower; no impact on the standard on-demand path.
+
 ### July 15, 2026
 `4.0.2`
 - Add `Lambda-Runtime-Invocation-Id` header support for cross-wiring protection. The RIC now echoes the invocation ID received from RAPID on `/next` back on `/response` and `/error`, enabling RAPID to detect and reject stale responses from timed-out invocations.

--- a/awslambdaric/__init__.py
+++ b/awslambdaric/__init__.py
@@ -2,4 +2,4 @@
 Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"

--- a/awslambdaric/bootstrap.py
+++ b/awslambdaric/bootstrap.py
@@ -493,6 +493,16 @@ def _log_preview_runtime_warning():
         logging.warning(get_lambda_preview_runtime_warning_message())
 
 
+def init_logging():
+    """Setup logging for the parent process before forking (LMI only)."""
+    sys.stdout = Unbuffered(sys.stdout)
+    sys.stderr = Unbuffered(sys.stderr)
+    log_sink = create_log_sink()
+    log_sink.__enter__()
+    _setup_logging(_AWS_LAMBDA_LOG_FORMAT, _AWS_LAMBDA_LOG_LEVEL, log_sink)
+    return log_sink
+
+
 def run(handler, lambda_runtime_client):
     sys.stdout = Unbuffered(sys.stdout)
     sys.stderr = Unbuffered(sys.stderr)

--- a/awslambdaric/lambda_multi_concurrent_utils.py
+++ b/awslambdaric/lambda_multi_concurrent_utils.py
@@ -36,10 +36,13 @@ class MultiConcurrentRunner:
         bootstrap.run(handler, client)
 
     @classmethod
-    def _emit_worker_pool_event(cls, socket_path: str, max_concurrency: int):
-        """Emit worker pool DEBUG event once from the parent before forking."""
-        if socket_path:
-            cls._redirect_output(socket_path)
+    def _emit_worker_pool_event(cls, max_concurrency: int):
+        """Emit worker pool DEBUG event once from the parent before forking.
+
+        No output redirection here: RAPID wires the runtime main process's
+        stdout/stderr to the log egress at spawn. The FD provider socket is
+        only for the forked workers, which redirect in run_single.
+        """
         log_sink = bootstrap.init_logging()
         logging.getLogger().debug(
             {
@@ -62,7 +65,7 @@ class MultiConcurrentRunner:
         socket_path: str,
         max_concurrency: int,
     ):
-        cls._emit_worker_pool_event(socket_path, max_concurrency)
+        cls._emit_worker_pool_event(max_concurrency)
 
         processes = []
         for _ in range(max_concurrency):

--- a/awslambdaric/lambda_multi_concurrent_utils.py
+++ b/awslambdaric/lambda_multi_concurrent_utils.py
@@ -40,7 +40,7 @@ class MultiConcurrentRunner:
         """Emit worker pool DEBUG event once from the parent before forking."""
         if socket_path:
             cls._redirect_output(socket_path)
-        bootstrap.init_logging()
+        log_sink = bootstrap.init_logging()
         logging.getLogger().debug(
             {
                 "event": WORKER_POOL_INITIALIZING_EVENT,
@@ -49,6 +49,9 @@ class MultiConcurrentRunner:
             }
         )
         logging.getLogger().handlers.clear()
+        # Close the sink deterministically now that its handler is gone
+        # (no-op for StandardLogSink; releases the fd for framed sinks).
+        log_sink.__exit__(None, None, None)
 
     @classmethod
     def run_concurrent(

--- a/awslambdaric/lambda_multi_concurrent_utils.py
+++ b/awslambdaric/lambda_multi_concurrent_utils.py
@@ -2,6 +2,7 @@
 Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
+import logging
 import os
 import sys
 import socket
@@ -9,6 +10,8 @@ import multiprocessing
 
 from . import bootstrap
 from .lambda_runtime_client import LambdaMultiConcurrentRuntimeClient
+
+WORKER_POOL_INITIALIZING_EVENT = "runtime_worker_pool_initializing"
 
 
 class MultiConcurrentRunner:
@@ -33,6 +36,21 @@ class MultiConcurrentRunner:
         bootstrap.run(handler, client)
 
     @classmethod
+    def _emit_worker_pool_event(cls, socket_path: str, max_concurrency: int):
+        """Emit worker pool DEBUG event once from the parent before forking."""
+        if socket_path:
+            cls._redirect_output(socket_path)
+        bootstrap.init_logging()
+        logging.getLogger().debug(
+            {
+                "event": WORKER_POOL_INITIALIZING_EVENT,
+                "workerCount": max_concurrency,
+                "executionEnvironmentMaxConcurrency": max_concurrency,
+            }
+        )
+        logging.getLogger().handlers.clear()
+
+    @classmethod
     def run_concurrent(
         cls,
         handler: str,
@@ -41,6 +59,8 @@ class MultiConcurrentRunner:
         socket_path: str,
         max_concurrency: int,
     ):
+        cls._emit_worker_pool_event(socket_path, max_concurrency)
+
         processes = []
         for _ in range(max_concurrency):
             p = multiprocessing.Process(

--- a/awslambdaric/lambda_runtime_log_utils.py
+++ b/awslambdaric/lambda_runtime_log_utils.py
@@ -68,7 +68,10 @@ _TEXT_FRAME_TYPES = {
 }
 _DEFAULT_FRAME_TYPE = _TEXT_FRAME_TYPES[logging.NOTSET]
 
-_json_encoder = json.JSONEncoder(ensure_ascii=False)
+# default=str keeps formatting resilient: non-JSON-serializable values in
+# dict messages or `extra` attributes are stringified instead of raising and
+# dropping the whole log record.
+_json_encoder = json.JSONEncoder(ensure_ascii=False, default=str)
 _encode_json = _json_encoder.encode
 
 

--- a/awslambdaric/lambda_runtime_log_utils.py
+++ b/awslambdaric/lambda_runtime_log_utils.py
@@ -117,7 +117,11 @@ class JsonFormatter(logging.Formatter):
         result = {
             "timestamp": self.formatTime(record, self.datefmt),
             "level": record.levelname,
-            "message": record.getMessage(),
+            "message": (
+                record.msg
+                if isinstance(record.msg, dict) and not record.args
+                else record.getMessage()
+            ),
             "logger": record.name,
             "stackTrace": self.__format_stacktrace(record.exc_info),
             "errorType": self.__format_exception_name(record.exc_info),

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1613,6 +1613,32 @@ class TestWorkerPoolInitializedLog(unittest.TestCase):
         self.assertEqual(data["level"], "DEBUG")
         self.assertEqual(data["message"]["event"], "runtime_worker_pool_initializing")
 
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_dict_message_with_non_serializable_values_is_not_dropped(
+        self, mock_stdout
+    ):
+        import datetime
+        import decimal
+
+        self._setup_json_logging("DEBUG")
+
+        logging.getLogger().debug(
+            {
+                "event": "custom_event",
+                "when": datetime.datetime(2026, 9, 3, 12, 0, 0),
+                "amount": decimal.Decimal("1.5"),
+                "blob": b"bytes",
+            }
+        )
+
+        # The record must not be dropped: it serializes with values
+        # stringified via the encoder's default=str fallback.
+        data = json.loads(mock_stdout.getvalue())
+        self.assertEqual(data["message"]["event"], "custom_event")
+        self.assertEqual(data["message"]["when"], "2026-09-03 12:00:00")
+        self.assertEqual(data["message"]["amount"], "1.5")
+        self.assertEqual(data["message"]["blob"], "b'bytes'")
+
 
 class TestBootstrapModule(unittest.TestCase):
     def test_run(self):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1540,6 +1540,80 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(mock_stdout.getvalue(), "")
 
 
+class TestWorkerPoolInitializedLog(unittest.TestCase):
+    def setUp(self):
+        logging.getLogger().handlers.clear()
+        logging.getLogger().level = logging.NOTSET
+
+    def tearDown(self):
+        logging.getLogger().handlers.clear()
+        logging.getLogger().level = logging.NOTSET
+
+    def _setup_json_logging(self, log_level):
+        bootstrap._setup_logging(
+            LogFormat.from_str("JSON"), log_level, bootstrap.StandardLogSink()
+        )
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_dict_message_serialized_as_nested_json_at_debug(self, mock_stdout):
+        self._setup_json_logging("DEBUG")
+
+        logging.getLogger().debug(
+            {
+                "event": "runtime_worker_pool_initializing",
+                "workerCount": 17,
+                "executionEnvironmentMaxConcurrency": 34,
+            }
+        )
+
+        data = json.loads(mock_stdout.getvalue().strip())
+        self.assertEqual(data["level"], "DEBUG")
+        self.assertEqual(
+            data["message"],
+            {
+                "event": "runtime_worker_pool_initializing",
+                "workerCount": 17,
+                "executionEnvironmentMaxConcurrency": 34,
+            },
+        )
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_not_emitted_at_higher_log_levels(self, mock_stdout):
+        for log_level in ("INFO", "WARN", "ERROR", "FATAL"):
+            with self.subTest(log_level):
+                logging.getLogger().handlers.clear()
+                logging.getLogger().level = logging.NOTSET
+                self._setup_json_logging(_get_log_level_from_env_var(log_level))
+
+                logging.getLogger().debug({"event": "test"})
+
+                self.assertEqual(mock_stdout.getvalue(), "")
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_init_logging_enables_parent_emission(self, mock_stdout):
+        with patch.dict(
+            os.environ,
+            {"AWS_LAMBDA_LOG_FORMAT": "JSON", "AWS_LAMBDA_LOG_LEVEL": "DEBUG"},
+            clear=True,
+        ):
+            importlib.reload(bootstrap)
+            bootstrap.init_logging()
+
+            logging.getLogger().debug(
+                {
+                    "event": "runtime_worker_pool_initializing",
+                    "workerCount": 4,
+                    "executionEnvironmentMaxConcurrency": 4,
+                }
+            )
+
+        importlib.reload(bootstrap)
+
+        data = json.loads(mock_stdout.getvalue())
+        self.assertEqual(data["level"], "DEBUG")
+        self.assertEqual(data["message"]["event"], "runtime_worker_pool_initializing")
+
+
 class TestBootstrapModule(unittest.TestCase):
     def test_run(self):
         expected_handler = "app.my_test_handler"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -39,6 +39,8 @@ class LambdaRuntimeConcurrencyTest(unittest.TestCase):
         with patch(
             "awslambdaric.lambda_multi_concurrent_utils.MultiConcurrentRunner._redirect_output"
         ), patch(
+            "awslambdaric.lambda_multi_concurrent_utils.MultiConcurrentRunner._emit_worker_pool_event"
+        ), patch(
             "awslambdaric.lambda_multi_concurrent_utils.bootstrap.run",
             side_effect=fake_bootstrap_run,
         ):

--- a/tests/test_multi_concurrent_runner.py
+++ b/tests/test_multi_concurrent_runner.py
@@ -4,7 +4,7 @@ Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 from awslambdaric.lambda_multi_concurrent_utils import MultiConcurrentRunner
 
@@ -58,8 +58,9 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
         mock_client_cls.assert_called_once_with("addr", True)
         mock_bootstrap.run.assert_called_once_with("h.fn", mock_client)
 
+    @patch.object(MultiConcurrentRunner, "_emit_worker_pool_event")
     @patch("multiprocessing.Process")
-    def test_run_concurrent_spawns_and_joins(self, mock_process):
+    def test_run_concurrent_spawns_and_joins(self, mock_process, mock_emit):
         fake_proc = MagicMock()
         mock_process.return_value = fake_proc
 
@@ -76,6 +77,53 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
             args = call_args.kwargs.get("args") or call_args[1].get("args")
             self.assertEqual(target, MultiConcurrentRunner.run_single)
             self.assertEqual(args, ("h", "a", False, "/sock"))
+
+    @patch("multiprocessing.Process")
+    def test_run_concurrent_emits_worker_pool_event_once_before_spawning(
+        self, mock_process
+    ):
+        mock_process.return_value = MagicMock()
+        order_tracker = MagicMock()
+        order_tracker.attach_mock(mock_process, "process")
+
+        with patch.object(
+            MultiConcurrentRunner, "_emit_worker_pool_event"
+        ) as mock_emit:
+            order_tracker.attach_mock(mock_emit, "emit")
+            MultiConcurrentRunner.run_concurrent(
+                "h", "a", False, "/sock", max_concurrency=3
+            )
+
+        mock_emit.assert_called_once_with("/sock", 3)
+        self.assertEqual(order_tracker.mock_calls[0], call.emit("/sock", 3))
+
+    @patch("awslambdaric.lambda_multi_concurrent_utils.logging")
+    @patch("awslambdaric.lambda_multi_concurrent_utils.bootstrap")
+    def test_emit_worker_pool_event_sets_up_parent_logging_and_emits(
+        self, mock_bootstrap, mock_logging
+    ):
+        with patch.object(MultiConcurrentRunner, "_redirect_output") as mock_redirect:
+            MultiConcurrentRunner._emit_worker_pool_event("/sock", 16)
+
+        mock_redirect.assert_called_once_with("/sock")
+        mock_bootstrap.init_logging.assert_called_once_with()
+        mock_logging.getLogger.return_value.debug.assert_called_once()
+        event = mock_logging.getLogger.return_value.debug.call_args[0][0]
+        self.assertEqual(event["workerCount"], 16)
+        self.assertEqual(event["executionEnvironmentMaxConcurrency"], 16)
+        mock_logging.getLogger.return_value.handlers.clear.assert_called_once_with()
+
+    @patch("awslambdaric.lambda_multi_concurrent_utils.logging")
+    @patch("awslambdaric.lambda_multi_concurrent_utils.bootstrap")
+    def test_emit_worker_pool_event_skips_redirect_when_no_socket(
+        self, mock_bootstrap, mock_logging
+    ):
+        with patch.object(MultiConcurrentRunner, "_redirect_output") as mock_redirect:
+            MultiConcurrentRunner._emit_worker_pool_event(None, 4)
+
+        mock_redirect.assert_not_called()
+        mock_bootstrap.init_logging.assert_called_once_with()
+        mock_logging.getLogger.return_value.debug.assert_called_once()
 
     @patch(
         "awslambdaric.lambda_multi_concurrent_utils.LambdaMultiConcurrentRuntimeClient"

--- a/tests/test_multi_concurrent_runner.py
+++ b/tests/test_multi_concurrent_runner.py
@@ -94,8 +94,8 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
                 "h", "a", False, "/sock", max_concurrency=3
             )
 
-        mock_emit.assert_called_once_with("/sock", 3)
-        self.assertEqual(order_tracker.mock_calls[0], call.emit("/sock", 3))
+        mock_emit.assert_called_once_with(3)
+        self.assertEqual(order_tracker.mock_calls[0], call.emit(3))
 
     @patch("awslambdaric.lambda_multi_concurrent_utils.logging")
     @patch("awslambdaric.lambda_multi_concurrent_utils.bootstrap")
@@ -103,9 +103,10 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
         self, mock_bootstrap, mock_logging
     ):
         with patch.object(MultiConcurrentRunner, "_redirect_output") as mock_redirect:
-            MultiConcurrentRunner._emit_worker_pool_event("/sock", 16)
+            MultiConcurrentRunner._emit_worker_pool_event(16)
 
-        mock_redirect.assert_called_once_with("/sock")
+        # Parent never redirects: RAPID wires its stdout at spawn.
+        mock_redirect.assert_not_called()
         mock_bootstrap.init_logging.assert_called_once_with()
         mock_logging.getLogger.return_value.debug.assert_called_once()
         event = mock_logging.getLogger.return_value.debug.call_args[0][0]
@@ -116,18 +117,6 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
         mock_bootstrap.init_logging.return_value.__exit__.assert_called_once_with(
             None, None, None
         )
-
-    @patch("awslambdaric.lambda_multi_concurrent_utils.logging")
-    @patch("awslambdaric.lambda_multi_concurrent_utils.bootstrap")
-    def test_emit_worker_pool_event_skips_redirect_when_no_socket(
-        self, mock_bootstrap, mock_logging
-    ):
-        with patch.object(MultiConcurrentRunner, "_redirect_output") as mock_redirect:
-            MultiConcurrentRunner._emit_worker_pool_event(None, 4)
-
-        mock_redirect.assert_not_called()
-        mock_bootstrap.init_logging.assert_called_once_with()
-        mock_logging.getLogger.return_value.debug.assert_called_once()
 
     @patch(
         "awslambdaric.lambda_multi_concurrent_utils.LambdaMultiConcurrentRuntimeClient"

--- a/tests/test_multi_concurrent_runner.py
+++ b/tests/test_multi_concurrent_runner.py
@@ -112,6 +112,10 @@ class TestMultiConcurrentRunnerRedirect(unittest.TestCase):
         self.assertEqual(event["workerCount"], 16)
         self.assertEqual(event["executionEnvironmentMaxConcurrency"], 16)
         mock_logging.getLogger.return_value.handlers.clear.assert_called_once_with()
+        # Sink is closed deterministically after the handler is removed.
+        mock_bootstrap.init_logging.return_value.__exit__.assert_called_once_with(
+            None, None, None
+        )
 
     @patch("awslambdaric.lambda_multi_concurrent_utils.logging")
     @patch("awslambdaric.lambda_multi_concurrent_utils.bootstrap")


### PR DESCRIPTION
## Description

On [Lambda Managed Instances](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances.html),
the runtime sizes and spawns a worker pool during initialization to handle
multiple concurrent invocations per execution environment. Today there is no
way to observe the effective pool size: it can be influenced by configuration,
but nothing confirms what the runtime actually resolved.

This change adds a one-time structured JSON log event, emitted at DEBUG level
during runtime initialization, reporting the resolved worker pool size and the
maximum concurrency the execution environment supports. Both values are
included so the worker count is not mistaken for the supported concurrency.

Example (visible when the function's application log level is DEBUG or lower):

```json
{
  "timestamp": "...",
  "level": "DEBUG",
  "message": {
    "event": "runtime_worker_pool_initializing",
    "workerCount": 17,
    "executionEnvironmentMaxConcurrency": 34
  }
}
```

Design notes:
- Emitted exactly once per execution environment, during init — never per invoke.
- Opt-in by design: routed through the runtime's standard log-level filtering,
  so it only appears when the application log level is set to DEBUG or lower.
  Default configurations see no new log lines and no added CloudWatch cost.
- No new dependencies and no eager loading: emission reuses logging machinery
  already initialized during bootstrap.
- No behavior change on the standard (single-concurrency) compute type; that
  path is untouched.
- The nested message object is queryable in CloudWatch Logs Insights
  (e.g. `filter message.event = "runtime_worker_pool_initializing"`).

See also: [Python runtime for Lambda Managed Instances](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances-python-runtime.html)

## Testing

- Full unit test suite passes; new tests cover: emitted exactly once with the
  correct schema and values, suppressed at INFO and above, and not emitted on
  the single-concurrency path.
- Validated end to end on Lambda Managed Instances: event appears once per
  execution environment at DEBUG, never appears at INFO or above, and repeated
  sequential/concurrent invocations neither re-emit the event nor affect
  normal invocation logs.
