### PR TITLE
ci: replace EOL Debian bullseye with trixie in integration matrix

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -103,20 +103,24 @@ jobs:
             runtime_version: "3.14"
             python_location: /usr/local/bin/python
           - distro: debian
-            distro_version: bullseye
+            distro_version: trixie
             runtime_version: "3.10"
             python_location: /usr/local/bin/python
           - distro: debian
-            distro_version: bullseye
+            distro_version: trixie
             runtime_version: "3.11"
             python_location: /usr/local/bin/python
           - distro: debian
-            distro_version: bullseye
+            distro_version: trixie
             runtime_version: "3.12"
             python_location: /usr/local/bin/python
           - distro: debian
-            distro_version: bullseye
+            distro_version: trixie
             runtime_version: "3.13"
+            python_location: /usr/local/bin/python
+          - distro: debian
+            distro_version: trixie
+            runtime_version: "3.14"
             python_location: /usr/local/bin/python
           # Amazon Linux 2
           - distro: amazonlinux2


### PR DESCRIPTION
Debian 11 bullseye's bullseye-security apt Release file has expired on the mirror, causing 'apt-get update' to fail (exit 100) in the echo Dockerfile and breaking all bullseye integration jobs regardless of Python version. Bullseye is oldstable/EOL-track; replace it with the current stable release, trixie (Debian 13), across Python 3.10-3.14.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
